### PR TITLE
added nicer errors for invalid status codes in

### DIFF
--- a/lib/addMethod/validateExpects.js
+++ b/lib/addMethod/validateExpects.js
@@ -1,7 +1,7 @@
 /*
 * Validate a response vs expected status codes and body.
-* 
-* When something is not right, an __object__ is returned, containing 
+*
+* When something is not right, an __object__ is returned, containing
 * full details on the response and how it compared to the expected values.
 * Sample object:
 
@@ -13,7 +13,7 @@
     // slimmed down version of the `res` that was actually returned
     response: {
       statusCode: 201,
-      body: { 
+      body: {
         created: true
       }
     },
@@ -38,9 +38,9 @@ module.exports = function (res, expects) {
 
   // Setup the key variables
   var statusCode  = res.statusCode;
-  var bodyString  = stringify(res.body); 
+  var bodyString  = stringify(res.body);
   var errResponse = {
-    statusCode: res.statusCode, 
+    statusCode: res.statusCode,
     body: res.body
   };
 
@@ -64,13 +64,41 @@ module.exports = function (res, expects) {
   // Check the status codes - allow for ANY of them
   if (_.isArray(expects.statusCode)) {
     if (expects.statusCode.indexOf(res.statusCode) === -1) {
-      return {
-        code: 'invalid_response_status_code',
-        message: 'Invalid response status code',
+
+      var niceErrors = {
+        400: {
+          code: 'bad_request',
+          message: 'Bad API request. Try checking your input properties.'
+        },
+        401: {
+          code: 'unauthorized',
+          message: 'Unauthorized request. Have you added your API details correctly?'
+        },
+        403: {
+          code: 'forbidden',
+          message: 'Forbidden. Check you have the appropriate permissions to access this resource.'
+        },
+        404: {
+          code: 'not_found',
+          message: 'Not found. Looks like this has been removed.'
+        }
+      };
+
+      var error = {
         response: errResponse,
         expects: expects,
       };
-    } 
+
+      if (niceErrors[res.statusCode]) {
+        error.code = niceErrors[res.statusCode].code;
+        error.message = niceErrors[res.statusCode].message;
+      } else {
+        error.code = 'invalid_response_status_code';
+        error.message = 'Invalid response status code';
+      }
+
+      return error;
+    }
   }
 
   // Check the body strings - must have ALL of them
@@ -90,5 +118,3 @@ module.exports = function (res, expects) {
   }
 
 };
-
-

--- a/tests/validateExpects_test.js
+++ b/tests/validateExpects_test.js
@@ -35,6 +35,24 @@ describe('#validateExpects', function () {
   });
 
 
+  it('should make the errors nicely for certain invalid status codes', function () {
+    _.each([400, 401, 403, 404], function (statusCode) {
+
+      var err = validateExpects({
+        statusCode: statusCode
+      }, {
+        statusCode: [202]
+      });
+      assert(_.isObject(err));
+      assert(err.code.length);
+      assert(err.message.length);
+      assert.notEqual(err.code, 'invalid_response_status_code');
+      assert.notEqual(err.message, 'Invalid response status code');
+
+    });
+  });
+
+
   it('it should be ok with valid bodies', function () {
     var err = validateExpects({
       body: {
@@ -78,6 +96,6 @@ describe('#validateExpects', function () {
     assert.equal(err.code, 'invalid_response_body');
     assert.equal(err.message, 'Invalid response body');
   });
-  
+
 
 });


### PR DESCRIPTION
For the `expects` parameter in threadneedle, if there's an invalid status code returned with a commonly used error code (e.g. not found, forbidden) then show a nicer error code and message to the user.

Right now we're showing "Invalid response status code" in loads of workflow logs - which makes very little sense.

Currently handles:

* 400 
* 401
* 403
* 404