### PR TITLE
fix for not running global and local function expects

### DIFF
--- a/lib/addMethod/globalize/expects.js
+++ b/lib/addMethod/globalize/expects.js
@@ -12,10 +12,22 @@ module.exports = function (config) {
 	var globalExpects = normalizeExpects(this._globalOptions.expects || {});
 	var localExpects  = normalizeExpects(config.expects || {});
 
+	// If globals disabled, only pass back local expects in an array of one
 	if (config.globals === false) {
-		return localExpects;
-	} else {
-		return _.defaults(localExpects, globalExpects);
+		return [ localExpects ];
+	}
+
+	// If both global and local expects are not functions, merge the two
+	// objects and pass back an array of one.
+	else if (!_.isFunction(globalExpects) && !_.isFunction(localExpects)) {
+		return [ _.defaults(localExpects, globalExpects) ];
+	}
+
+	// If one of the global or local expects is a function, return an array of
+	// two functions to be executed sequentially. Global expects will be executed
+	// before local expects.
+	else {
+		return [ globalExpects, localExpects ];
 	}
 
 };

--- a/lib/addMethod/globalize/notExpects.js
+++ b/lib/addMethod/globalize/notExpects.js
@@ -12,10 +12,22 @@ module.exports = function (config) {
 	var globalNotExpects = normalizeExpects(this._globalOptions.notExpects || {});
 	var localNotExpects  = normalizeExpects(config.notExpects || {});
 
+	// If globals are false, just return the local not expects
 	if (config.globals === false) {
-		return localNotExpects;
-	} else {
-		return _.defaults(localNotExpects, globalNotExpects);
+		return [ localNotExpects ];
+	}
+
+	// If both global and local not expects are not functions, merge the two
+	// objects and pass back an array of one.
+	else if (!_.isFunction(globalNotExpects) && !_.isFunction(localNotExpects)) {
+		return [ _.defaults(localNotExpects, globalNotExpects) ];
+	}
+
+	// If one of the global or local not expects is a function, return an array of
+	// two functions to be executed sequentially. Global not expects will be executed
+	// before local expects.
+	else {
+		return [ globalNotExpects, localNotExpects ];
 	}
 
 };

--- a/lib/addMethod/validateExpects.js
+++ b/lib/addMethod/validateExpects.js
@@ -34,7 +34,7 @@ var _                = require('lodash');
 var stringify        = require('./stringify');
 
 
-module.exports = function (res, expects) {
+module.exports = function (res, expectsArr) {
 
   // Setup the key variables
   var statusCode  = res.statusCode;
@@ -44,76 +44,88 @@ module.exports = function (res, expects) {
     body: res.body
   };
 
-  // Array of errors objects to build up
-  var errors = [];
+  // Error to return.
+  var error;
 
-  // Run function if needed
-  if (_.isFunction(expects)) {
-    fnErrorMessage = expects.call(null, res);
-    if (fnErrorMessage) {
-      return {
-        code: 'invalid_response_function',
-        response: errResponse,
-        message: fnErrorMessage
-      };
+  // `expects` is an array of up to two items
+  _.each(expectsArr, function (expects) {
+
+    // If already set the error don't carry on
+    if (error) {
+      return;
     }
-  }
 
-
-  // Check the status codes - allow for ANY of them
-  if (_.isArray(expects.statusCode)) {
-    if (expects.statusCode.indexOf(res.statusCode) === -1) {
-
-      var niceErrors = {
-        400: {
-          code: 'bad_request',
-          message: 'Bad API request. Try checking your input properties.'
-        },
-        401: {
-          code: 'unauthorized',
-          message: 'Unauthorized request. Have you added your API details correctly?'
-        },
-        403: {
-          code: 'forbidden',
-          message: 'Forbidden. Check you have the appropriate permissions to access this resource.'
-        },
-        404: {
-          code: 'not_found',
-          message: 'Not found. Looks like this has been removed.'
-        }
-      };
-
-      var error = {
-        response: errResponse,
-        expects: expects,
-      };
-
-      if (niceErrors[res.statusCode]) {
-        error.code = niceErrors[res.statusCode].code;
-        error.message = niceErrors[res.statusCode].message;
-      } else {
-        error.code = 'invalid_response_status_code';
-        error.message = 'Invalid response status code';
+    // Run function if needed
+    if (_.isFunction(expects)) {
+      fnErrorMessage = expects.call(null, res);
+      if (fnErrorMessage) {
+        error = {
+          code: 'invalid_response_function',
+          response: errResponse,
+          message: fnErrorMessage
+        };
       }
-
-      return error;
     }
-  }
 
-  // Check the body strings - must have ALL of them
-  if (_.isArray(expects.body)) {
-    var missing = _.filter(expects.body, function (pattern) {
-      return bodyString.indexOf(pattern) === -1;
-    });
 
-    if (missing.length) {
-      return {
-        code: 'invalid_response_body',
-        message: 'Invalid response body',
-        response: errResponse,
-        expects: expects
-      };
+    // Check the status codes - allow for ANY of them
+    if (_.isArray(expects.statusCode)) {
+      if (expects.statusCode.indexOf(res.statusCode) === -1) {
+
+        var niceErrors = {
+          400: {
+            code: 'bad_request',
+            message: 'Bad API request. Try checking your input properties.'
+          },
+          401: {
+            code: 'unauthorized',
+            message: 'Unauthorized request. Have you added your API details correctly?'
+          },
+          403: {
+            code: 'forbidden',
+            message: 'Forbidden. Check you have the appropriate permissions to access this resource.'
+          },
+          404: {
+            code: 'not_found',
+            message: 'Not found. Looks like this has been removed.'
+          }
+        };
+
+        var statusError = {
+          response: errResponse,
+          expects: expects,
+        };
+
+        if (niceErrors[res.statusCode]) {
+          statusError.code = niceErrors[res.statusCode].code;
+          statusError.message = niceErrors[res.statusCode].message;
+        } else {
+          statusError.code = 'invalid_response_status_code';
+          statusError.message = 'Invalid response status code';
+        }
+
+        error = statusError;
+      }
     }
-  }
+
+    // Check the body strings - must have ALL of them
+    if (_.isArray(expects.body)) {
+      var missing = _.filter(expects.body, function (pattern) {
+        return bodyString.indexOf(pattern) === -1;
+      });
+
+      if (missing.length) {
+        error = {
+          code: 'invalid_response_body',
+          message: 'Invalid response body',
+          response: errResponse,
+          expects: expects
+        };
+      }
+    }
+
+  });
+
+  return error;
 
 };

--- a/lib/addMethod/validateNotExpects.js
+++ b/lib/addMethod/validateNotExpects.js
@@ -34,7 +34,7 @@ var _                = require('lodash');
 var stringify        = require('./stringify');
 
 
-module.exports = function (res, notExpects) {
+module.exports = function (res, notExpectsArr) {
 
   // Setup the key variables
   var statusCode  = res.statusCode;
@@ -44,48 +44,59 @@ module.exports = function (res, notExpects) {
     body: res.body
   };
 
-  // Array of errors objects to build up
-  var errors = [];
+  // Error message to return
+  var error;
 
-  // Run function if needed
-  if (_.isFunction(notExpects)) {
-    fnErrorMessage = notExpects.call(null, res);
-    if (fnErrorMessage) {
-      return {
-        code: 'invalid_response_function',
-        response: errResponse,
-        message: fnErrorMessage
-      };
+  _.each(notExpectsArr, function (notExpects) {
+
+    // Don't check if already got an error
+    if (error) {
+      return;
     }
-  }
 
-
-  // Check the status codes - must have NONE of them
-  if (_.isArray(notExpects.statusCode)) {
-    if (notExpects.statusCode.indexOf(res.statusCode) !== -1) {
-      return {
-        code: 'invalid_response_status_code',
-        message: 'Invalid response status code',
-        response: errResponse,
-        notExpects: notExpects
-      };
+    // Run function if needed
+    if (_.isFunction(notExpects)) {
+      fnErrorMessage = notExpects.call(null, res);
+      if (fnErrorMessage) {
+        error = {
+          code: 'invalid_response_function',
+          response: errResponse,
+          message: fnErrorMessage
+        };
+      }
     }
-  }
 
-  // Check the body strings - must have NONE of them
-  if (_.isArray(notExpects.body)) {
-    var found = _.filter(notExpects.body, function (pattern) {
-      return bodyString.indexOf(pattern) !== -1;
-    });
 
-    if (found.length) {
-      return {
-        code: 'invalid_response_body',
-        message: 'Invalid response body',
-        response: errResponse,
-        notExpects: notExpects
-      };
+    // Check the status codes - must have NONE of them
+    if (_.isArray(notExpects.statusCode)) {
+      if (notExpects.statusCode.indexOf(res.statusCode) !== -1) {
+        error = {
+          code: 'invalid_response_status_code',
+          message: 'Invalid response status code',
+          response: errResponse,
+          notExpects: notExpects
+        };
+      }
     }
-  }
+
+    // Check the body strings - must have NONE of them
+    if (_.isArray(notExpects.body)) {
+      var found = _.filter(notExpects.body, function (pattern) {
+        return bodyString.indexOf(pattern) !== -1;
+      });
+
+      if (found.length) {
+        error = {
+          code: 'invalid_response_body',
+          message: 'Invalid response body',
+          response: errResponse,
+          notExpects: notExpects
+        };
+      }
+    }
+
+  });
+
+  return error;
 
 };

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -339,7 +339,7 @@ describe('#globalize', function () {
           expects: 200
         }
       };
-      assert.deepEqual(globalize.expects.call(sample, {}), { statusCode: [200] });
+      assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
 
       var sample = {
         _globalOptions: {
@@ -349,10 +349,10 @@ describe('#globalize', function () {
           }
         }
       };
-      assert.deepEqual(globalize.expects.call(sample, {}), {
+      assert.deepEqual(globalize.expects.call(sample, {}), [{
         statusCode: [200, 201],
         body: ['chris']
-      });
+      }]);
     });
 
     it('should be overridden by the local config', function () {
@@ -365,15 +365,54 @@ describe('#globalize', function () {
         expects: {
           statusCode: 201
         }
-      }), {
+      }), [{
         statusCode: [201]
-      });
+      }]);
 
       assert.deepEqual(globalize.expects.call(sample, {
         expects: 202
-      }), {
+      }), [{
         statusCode: [202]
-      });
+      }]);
+    });
+
+    it('should not merge when there are functions on the global or local level', function () {
+      var sample = {
+        _globalOptions: {
+          expects: function () {
+            return 'Bad things';
+          }
+        }
+      };
+      assert.strictEqual(globalize.expects.call(sample, {
+        expects: {
+          body: 'steve'
+        }
+      }).length, 2);
+
+      var sample = {
+        _globalOptions: {
+          expects: function () {
+            return 'Bad things';
+          }
+        }
+      };
+      assert.strictEqual(globalize.expects.call(sample, {
+        expects: function () {
+          return 'Locally bad things';
+        }
+      }).length, 2);
+
+      var sample = {
+        _globalOptions: {
+          notExpects: [200]
+        }
+      };
+      assert.strictEqual(globalize.expects.call(sample, {
+        expects: function () {
+          return 'Locally bad things';
+        }
+      }).length, 2);
     });
 
     it('should not run global when globals is false', function () {
@@ -382,7 +421,7 @@ describe('#globalize', function () {
           expects: 200
         }
       };
-      assert.deepEqual(globalize.expects.call(sample, {}), { statusCode: [200] });
+      assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
 
       var sample = {
         _globalOptions: {
@@ -394,7 +433,7 @@ describe('#globalize', function () {
       };
       assert.deepEqual(globalize.expects.call(sample, {
         globals: false
-      }), {});
+      }), [{}]);
     });
 
   });
@@ -407,7 +446,7 @@ describe('#globalize', function () {
           notExpects: 200
         }
       };
-      assert.deepEqual(globalize.notExpects.call(sample, {}), { statusCode: [200] });
+      assert.deepEqual(globalize.notExpects.call(sample, {}), [{ statusCode: [200] }]);
 
       var sample = {
         _globalOptions: {
@@ -417,10 +456,10 @@ describe('#globalize', function () {
           }
         }
       };
-      assert.deepEqual(globalize.notExpects.call(sample, {}), {
+      assert.deepEqual(globalize.notExpects.call(sample, {}), [{
         statusCode: [200, 201],
         body: ['chris']
-      });
+      }]);
     });
 
     it('should be overridden by the local config', function () {
@@ -433,15 +472,15 @@ describe('#globalize', function () {
         notExpects: {
           statusCode: 201
         }
-      }), {
+      }), [{
         statusCode: [201]
-      });
+      }]);
 
       assert.deepEqual(globalize.notExpects.call(sample, {
         notExpects: 202
-      }), {
+      }), [{
         statusCode: [202]
-      });
+      }]);
     });
 
 
@@ -459,9 +498,48 @@ describe('#globalize', function () {
           body: 'steve'
         },
         globals: false
-      }), {
+      }), [{
         body: ['steve']
-      });
+      }]);
+    });
+
+    it('should not merge when there are functions on the global or local level', function () {
+      var sample = {
+        _globalOptions: {
+          notExpects: function () {
+            return 'Bad things';
+          }
+        }
+      };
+      assert.strictEqual(globalize.notExpects.call(sample, {
+        notExpects: {
+          body: 'steve'
+        }
+      }).length, 2);
+
+      var sample = {
+        _globalOptions: {
+          notExpects: function () {
+            return 'Bad things';
+          }
+        }
+      };
+      assert.strictEqual(globalize.notExpects.call(sample, {
+        notExpects: function () {
+          return 'Locally bad things';
+        }
+      }).length, 2);
+
+      var sample = {
+        _globalOptions: {
+          notExpects: [200]
+        }
+      };
+      assert.strictEqual(globalize.notExpects.call(sample, {
+        notExpects: function () {
+          return 'Locally bad things';
+        }
+      }).length, 2);
     });
 
   });

--- a/tests/validateExpects_test.js
+++ b/tests/validateExpects_test.js
@@ -8,27 +8,27 @@ describe('#validateExpects', function () {
   it('should be ok with valid status codes', function () {
     var err = validateExpects({
       statusCode: 201
-    }, {
+    }, [{
       statusCode: [201, 204]
-    });
+    }]);
     assert(_.isUndefined(err));
   });
 
   it('should not be ok with invalid status codes', function () {
     var err = validateExpects({
       statusCode: 201
-    }, {
+    }, [{
       statusCode: [202]
-    });
+    }]);
     assert(_.isObject(err));
     assert.equal(err.code, 'invalid_response_status_code');
     assert.equal(err.message, 'Invalid response status code');
 
     var err = validateExpects({
       statusCode: 201
-    }, {
+    }, [{
       statusCode: [202, 204]
-    });
+    }]);
     assert(_.isObject(err));
     assert.equal(err.code, 'invalid_response_status_code');
     assert.equal(err.message, 'Invalid response status code');
@@ -40,9 +40,9 @@ describe('#validateExpects', function () {
 
       var err = validateExpects({
         statusCode: statusCode
-      }, {
+      }, [{
         statusCode: [202]
-      });
+      }]);
       assert(_.isObject(err));
       assert(err.code.length);
       assert(err.message.length);
@@ -58,18 +58,18 @@ describe('#validateExpects', function () {
       body: {
         result: 'chris'
       }
-    }, {
+    }, [{
       body: ['chris']
-    });
+    }]);
     assert(_.isUndefined(err));
 
     var err = validateExpects({
       body: {
         result: 'chris'
       }
-    }, {
+    }, [{
       body: ['chris', 'result']
-    });
+    }]);
     assert(_.isUndefined(err));
   });
 
@@ -78,9 +78,9 @@ describe('#validateExpects', function () {
       body: {
         result: 'chris'
       }
-    }, {
+    }, [{
       body: ['christopher']
-    });
+    }]);
     assert(_.isObject(err));
     assert.equal(err.code, 'invalid_response_body');
     assert.equal(err.message, 'Invalid response body');
@@ -89,12 +89,36 @@ describe('#validateExpects', function () {
       body: {
         result: 'chris'
       }
-    }, {
+    }, [{
       body: ['chris', 'superresult']
-    });
+    }]);
     assert(_.isObject(err));
     assert.equal(err.code, 'invalid_response_body');
     assert.equal(err.message, 'Invalid response body');
+  });
+
+  it('should not be ok if a function returns an error', function () {
+    var err = validateExpects({
+      body: {
+        result: 'chris'
+      }
+    }, [function (res) {
+      return 'Bad things';
+    }]);
+    assert(_.isObject(err));
+    assert.equal(err.code, 'invalid_response_function');
+    assert.equal(err.message, 'Bad things');
+
+    var err = validateExpects({
+      body: {
+        result: 'chris'
+      }
+    }, [function (res) {}, function () {
+      return 'Very bad things';
+    }]);
+    assert(_.isObject(err));
+    assert.equal(err.code, 'invalid_response_function');
+    assert.equal(err.message, 'Very bad things');
   });
 
 

--- a/tests/validateNotExpects_test.js
+++ b/tests/validateNotExpects_test.js
@@ -8,34 +8,34 @@ describe('#validateNotExpects', function () {
   it('it should be ok with valid status codes', function () {
     var err = validateNotExpects({
       statusCode: 201
-    }, {
+    }, [{
       statusCode: [202]
-    });
+    }]);
     assert(_.isUndefined(err));
 
     var err = validateNotExpects({
       statusCode: 201
-    }, {
+    }, [{
       statusCode: [202, 204]
-    });
+    }]);
     assert(_.isUndefined(err));
   });
 
   it('it should not be ok with invalid status codes', function () {
     var err = validateNotExpects({
       statusCode: 201
-    }, {
+    }, [{
       statusCode: [201]
-    });
+    }]);
     assert(_.isObject(err));
     assert.equal(err.code, 'invalid_response_status_code');
     assert.equal(err.message, 'Invalid response status code');
 
     var err = validateNotExpects({
       statusCode: 201
-    }, {
+    }, [{
       statusCode: [201, 204]
-    });
+    }]);
     assert(_.isObject(err));
     assert.equal(err.code, 'invalid_response_status_code');
     assert.equal(err.message, 'Invalid response status code');
@@ -47,18 +47,18 @@ describe('#validateNotExpects', function () {
       body: {
         result: 'chris'
       }
-    }, {
+    }, [{
       body: ['christopher']
-    });
+    }]);
     assert(_.isUndefined(err));
 
     var err = validateNotExpects({
       body: {
         result: 'chris'
       }
-    }, {
+    }, [{
       body: ['christopher', 'result2']
-    });
+    }]);
     assert(_.isUndefined(err));
   });
 
@@ -67,9 +67,9 @@ describe('#validateNotExpects', function () {
       body: {
         result: 'chris'
       }
-    }, {
+    }, [{
       body: ['chris']
-    });
+    }]);
     assert(_.isObject(err));
     assert.equal(err.code, 'invalid_response_body');
     assert.equal(err.message, 'Invalid response body');
@@ -78,14 +78,39 @@ describe('#validateNotExpects', function () {
       body: {
         result: 'chris'
       }
-    }, {
+    }, [{
       body: ['chris', 'resulttest']
-    });
+    }]);
     assert(_.isObject(err));
     assert.equal(err.code, 'invalid_response_body');
     assert.equal(err.message, 'Invalid response body');
 
   });
-  
+
+  it('should not be ok if a function returns an error', function () {
+    var err = validateNotExpects({
+      body: {
+        result: 'chris'
+      }
+    }, [function (res) {
+      return 'Bad things';
+    }]);
+    assert(_.isObject(err));
+    assert.equal(err.code, 'invalid_response_function');
+    assert.equal(err.message, 'Bad things');
+
+    var err = validateNotExpects({
+      body: {
+        result: 'chris'
+      }
+    }, [function (res) {}, function () {
+      return 'Very bad things';
+    }]);
+    assert(_.isObject(err));
+    assert.equal(err.code, 'invalid_response_function');
+    assert.equal(err.message, 'Very bad things');
+  });
+
+
 
 });


### PR DESCRIPTION
Fix for https://github.com/trayio/threadneedle/issues/22.

The global and local expects data were merged using `_.defaults` which works great for objects, and great (weirdly) when a local `expects` or `notExpects` function is declared, but it meant that global functions do not run.

Changed things up now so if either of the global or local `expects` or `notExpects` are functions, a merge does not happen - the validations are run separately and sequentially.

Added a bunch of unit tests for this.

This covers all combinations of functions and functions, objects and objects, and functions and objects. In either order.

Global expects/notExpects validation runs before local, FYI.