### PR TITLE
Specific globals disabling

### DIFF
--- a/lib/addMethod/globalize/afterFailure.js
+++ b/lib/addMethod/globalize/afterFailure.js
@@ -13,9 +13,10 @@ module.exports = function (config, body, params) {
 
     // Run global promise first
     .then(function () {
-      if (_.isFunction(threadneedle._globalOptions.afterFailure) && config.globals !== false) {
-        return when(threadneedle._globalOptions.afterFailure(body, params));
-      }
+        var localOnly = config.globals === false || _.get(config, 'globals.afterFailure', true) === false;
+        if (_.isFunction(threadneedle._globalOptions.afterFailure) && !localOnly) {
+            return when(threadneedle._globalOptions.afterFailure(body, params));
+        }
     })
 
     // Then run the local prmoise

--- a/lib/addMethod/globalize/afterFailure.js
+++ b/lib/addMethod/globalize/afterFailure.js
@@ -13,8 +13,7 @@ module.exports = function (config, body, params) {
 
     // Run global promise first
     .then(function () {
-        var localOnly = config.globals === false || _.get(config, 'globals.afterFailure', true) === false;
-        if (_.isFunction(threadneedle._globalOptions.afterFailure) && !localOnly) {
+        if (_.isFunction(threadneedle._globalOptions.afterFailure) && !require('./localOnly')(config, 'afterFailure')) {
             return when(threadneedle._globalOptions.afterFailure(body, params));
         }
     })

--- a/lib/addMethod/globalize/afterSuccess.js
+++ b/lib/addMethod/globalize/afterSuccess.js
@@ -13,9 +13,10 @@ module.exports = function (config, body, params, res) {
 
     // Run global promise first
     .then(function () {
-      if (_.isFunction(threadneedle._globalOptions.afterSuccess) && config.globals !== false) {
+        var localOnly = config.globals === false || _.get(config, 'globals.afterSuccess', true) === false;
+        if (_.isFunction(threadneedle._globalOptions.afterSuccess) && !localOnly) {
         return when(threadneedle._globalOptions.afterSuccess(body, params, res));
-      }
+        }
     })
 
     // Then run the local prmoise

--- a/lib/addMethod/globalize/afterSuccess.js
+++ b/lib/addMethod/globalize/afterSuccess.js
@@ -13,8 +13,7 @@ module.exports = function (config, body, params, res) {
 
     // Run global promise first
     .then(function () {
-        var localOnly = config.globals === false || _.get(config, 'globals.afterSuccess', true) === false;
-        if (_.isFunction(threadneedle._globalOptions.afterSuccess) && !localOnly) {
+        if (_.isFunction(threadneedle._globalOptions.afterSuccess) && !require('./localOnly')(config, 'afterSuccess')) {
         return when(threadneedle._globalOptions.afterSuccess(body, params, res));
         }
     })

--- a/lib/addMethod/globalize/baseUrl.js
+++ b/lib/addMethod/globalize/baseUrl.js
@@ -11,14 +11,12 @@ module.exports = function (config, params) {
 
   var subbedGlobalUrl = substitute(this._globalOptions.baseUrl || this._globalOptions.url, params);
   var subbedUrl       = substitute(config.url, params);
-
-  var localOnly = config.globals === false || _.get(config, 'globals.baseUrl', true) === false;
-
+  
   // Add the URL
   if (_.isString(subbedGlobalUrl) &&
       !startsWith(subbedUrl, 'http://') &&
       !startsWith(subbedUrl, 'https://') &&
-      !localOnly) {
+      !require('./localOnly')(config, 'baseUrl')) {
     return subbedGlobalUrl + subbedUrl;
   }
 

--- a/lib/addMethod/globalize/baseUrl.js
+++ b/lib/addMethod/globalize/baseUrl.js
@@ -12,11 +12,13 @@ module.exports = function (config, params) {
   var subbedGlobalUrl = substitute(this._globalOptions.baseUrl || this._globalOptions.url, params);
   var subbedUrl       = substitute(config.url, params);
 
+  var localOnly = config.globals === false || _.get(config, 'globals.baseUrl', true) === false;
+
   // Add the URL
   if (_.isString(subbedGlobalUrl) &&
       !startsWith(subbedUrl, 'http://') &&
       !startsWith(subbedUrl, 'https://') &&
-      config.globals !== false) {
+      !localOnly) {
     return subbedGlobalUrl + subbedUrl;
   }
 

--- a/lib/addMethod/globalize/before.js
+++ b/lib/addMethod/globalize/before.js
@@ -17,8 +17,7 @@ module.exports = function (config, params) {
 
     // Run global promise first
     .then(function () {
-        var localOnly = config.globals === false || _.get(config, 'globals.before', true) === false;
-        if (_.isFunction(threadneedle._globalOptions.before) && !localOnly) {
+        if (_.isFunction(threadneedle._globalOptions.before) && !require('./localOnly')(config, 'before')) {
         return when(threadneedle._globalOptions.before(params));
         }
     })

--- a/lib/addMethod/globalize/before.js
+++ b/lib/addMethod/globalize/before.js
@@ -1,8 +1,8 @@
 /*
 * Run the global `before` method, and then the local method.
-* 
+*
 * Note that this is most often used to set/update parameters in the `params`
-* object - need to ensure that variables are passed and saved correctly in the 
+* object - need to ensure that variables are passed and saved correctly in the
 * tests pre substitution.
 */
 var when = require('when');
@@ -17,9 +17,10 @@ module.exports = function (config, params) {
 
     // Run global promise first
     .then(function () {
-      if (_.isFunction(threadneedle._globalOptions.before) && config.globals !== false) {
+        var localOnly = config.globals === false || _.get(config, 'globals.before', true) === false;
+        if (_.isFunction(threadneedle._globalOptions.before) && !localOnly) {
         return when(threadneedle._globalOptions.before(params));
-      }
+        }
     })
 
     // Then run the local prmoise

--- a/lib/addMethod/globalize/beforeRequest.js
+++ b/lib/addMethod/globalize/beforeRequest.js
@@ -13,7 +13,7 @@ module.exports = function (config, request, params) {
 
     // Run global promise first
     .then(function () {
-      if (_.isFunction(threadneedle._globalOptions.beforeRequest)) {
+      if (_.isFunction(threadneedle._globalOptions.beforeRequest) && !require('./localOnly')(config, 'beforeRequest')) {
         return when(threadneedle._globalOptions.beforeRequest(request, params));
       }
     })

--- a/lib/addMethod/globalize/expects.js
+++ b/lib/addMethod/globalize/expects.js
@@ -12,10 +12,8 @@ module.exports = function (config) {
 	var globalExpects = normalizeExpects(this._globalOptions.expects || {});
 	var localExpects  = normalizeExpects(config.expects || {});
 
-	var localOnly = config.globals === false || _.get(config, 'globals.expects', true) === false;
-
 	// If globals disabled, only pass back local expects in an array of one
-	if (localOnly) {
+	if (require('./localOnly')(config, 'expects')) {
 		return [ localExpects ];
 	}
 

--- a/lib/addMethod/globalize/expects.js
+++ b/lib/addMethod/globalize/expects.js
@@ -12,8 +12,10 @@ module.exports = function (config) {
 	var globalExpects = normalizeExpects(this._globalOptions.expects || {});
 	var localExpects  = normalizeExpects(config.expects || {});
 
+	var localOnly = config.globals === false || _.get(config, 'globals.expects', true) === false;
+
 	// If globals disabled, only pass back local expects in an array of one
-	if (config.globals === false || config.globals.expects === false) {
+	if (localOnly) {
 		return [ localExpects ];
 	}
 

--- a/lib/addMethod/globalize/expects.js
+++ b/lib/addMethod/globalize/expects.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
 	var localExpects  = normalizeExpects(config.expects || {});
 
 	// If globals disabled, only pass back local expects in an array of one
-	if (config.globals === false) {
+	if (config.globals === false || config.globals.expects === false) {
 		return [ localExpects ];
 	}
 

--- a/lib/addMethod/globalize/localOnly.js
+++ b/lib/addMethod/globalize/localOnly.js
@@ -1,0 +1,3 @@
+module.exports = function (config, key) {
+	return config.globals === false || require('lodash').get(config, 'globals.' + key, true) === false;
+};

--- a/lib/addMethod/globalize/notExpects.js
+++ b/lib/addMethod/globalize/notExpects.js
@@ -12,10 +12,8 @@ module.exports = function (config) {
 	var globalNotExpects = normalizeExpects(this._globalOptions.notExpects || {});
 	var localNotExpects  = normalizeExpects(config.notExpects || {});
 
-	var localOnly = config.globals === false || _.get(config, 'globals.notExpects', true) === false;
-
 	// If globals are false, just return the local not expects
-	if (localOnly) {
+	if (require('./localOnly')(config, 'notExpects')) {
 		return [ localNotExpects ];
 	}
 

--- a/lib/addMethod/globalize/notExpects.js
+++ b/lib/addMethod/globalize/notExpects.js
@@ -12,8 +12,10 @@ module.exports = function (config) {
 	var globalNotExpects = normalizeExpects(this._globalOptions.notExpects || {});
 	var localNotExpects  = normalizeExpects(config.notExpects || {});
 
+	var localOnly = config.globals === false || _.get(config, 'globals.notExpects', true) === false;
+
 	// If globals are false, just return the local not expects
-	if (config.globals === false) {
+	if (localOnly) {
 		return [ localNotExpects ];
 	}
 

--- a/lib/addMethod/globalize/object.js
+++ b/lib/addMethod/globalize/object.js
@@ -14,9 +14,7 @@ module.exports = function (key, config, params) {
     var subbedGlobalObject = substitute(this._globalOptions[key], params);
     var subbedObject       = substitute(config[key] || {}, params);
 
-    var localOnly = config.globals === false || _.get(config, 'globals.' + key, true) === false;
-
-    if (localOnly) {
+    if (require('./localOnly')(config, key)) {
         return subbedObject;
     } else {
         return _.defaultsDeep(subbedObject, subbedGlobalObject);

--- a/lib/addMethod/globalize/object.js
+++ b/lib/addMethod/globalize/object.js
@@ -14,10 +14,12 @@ module.exports = function (key, config, params) {
     var subbedGlobalObject = substitute(this._globalOptions[key], params);
     var subbedObject       = substitute(config[key] || {}, params);
 
-    if (config.globals === false) {
+    var localOnly = config.globals === false || _.get(config, 'globals.' + key, true) === false;
+
+    if (localOnly) {
         return subbedObject;
     } else {
         return _.defaultsDeep(subbedObject, subbedGlobalObject);
     }
-    
+
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/threadneedle",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A framework for simplifying working with HTTP-based APIs.",
   "main": "lib/index.js",
   "directories": {

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -97,6 +97,11 @@ describe('#globalize', function () {
         globalize.baseUrl.call(sample, { url: '/mypath', globals: false }, {}),
         '/mypath'
       );
+
+      assert.strictEqual(
+        globalize.baseUrl.call(sample, { url: '/mypath', globals: { baseUrl: false } }, {}),
+        '/mypath'
+      );
     });
 
   });
@@ -213,6 +218,21 @@ describe('#globalize', function () {
           height: 180
         }
       );
+
+      assert.deepEqual(
+        globalize.object.call(sample, 'data', {
+          globals: {
+              data: false
+          },
+          data: {
+            age: 25,
+            height: 180
+          }
+        }, {}), {
+          age: 25,
+          height: 180
+        }
+      );
     });
 
 
@@ -294,6 +314,17 @@ describe('#globalize', function () {
 
       globalize.before.call(sample, {
         globals: false,
+        url: '/mydomain/{{id}}'
+      }, {
+        id: '123'
+      }).done(function (params) {
+        assert.deepEqual(params, { id: '123' });
+      });
+
+      globalize.before.call(sample, {
+        globals: {
+            before: false
+        },
         url: '/mydomain/{{id}}'
       }, {
         id: '123'
@@ -436,6 +467,29 @@ describe('#globalize', function () {
       }), [{}]);
     });
 
+    it('should not run global when globals.expects is false', function () {
+      var sample = {
+        _globalOptions: {
+          expects: 200
+        }
+      };
+      assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
+
+      var sample = {
+        _globalOptions: {
+          expects: {
+            statusCode: [200, 201],
+            body: 'chris'
+          }
+        }
+      };
+      assert.deepEqual(globalize.expects.call(sample, {
+        globals: {
+            expects: false
+        }
+      }), [{}]);
+    });
+
   });
 
   describe('#notExpects', function () {
@@ -493,11 +547,23 @@ describe('#globalize', function () {
           }
         }
       };
+
       assert.deepEqual(globalize.notExpects.call(sample, {
         notExpects: {
           body: 'steve'
         },
         globals: false
+      }), [{
+        body: ['steve']
+      }]);
+
+      assert.deepEqual(globalize.notExpects.call(sample, {
+        notExpects: {
+          body: 'steve'
+        },
+        globals: {
+            notExpects: false
+        }
       }), [{
         body: ['steve']
       }]);
@@ -618,6 +684,15 @@ describe('#globalize', function () {
         globals: false
       }, {}).done(function (body) {
         assert.deepEqual(body, {});
+        //done();
+      });
+
+      globalize.afterSuccess.call(sample, {
+        globals: {
+            afterSuccess: false
+        }
+      }, {}).done(function (body) {
+        assert.deepEqual(body, {});
         done();
       });
     });
@@ -695,6 +770,15 @@ describe('#globalize', function () {
 
       globalize.afterFailure.call(sample, {
         globals: false
+      }, {}).done(function (err) {
+        assert.deepEqual(err, {});
+        //done();
+      });
+
+      globalize.afterFailure.call(sample, {
+        globals: {
+            afterFailure: false
+        }
       }, {}).done(function (err) {
         assert.deepEqual(err, {});
         done();


### PR DESCRIPTION
While `globals: false` still works for disabling *global_model.js* altogether for an operation, now it is possible to only disable specific parts.
Example:
```javascript
globals: {
    before: false
}
```
Will only prevent the `before` function in the global_model.js from running when executing that particular operation.