### PR TITLE
don't log the entire response object on failure

### DIFF
--- a/lib/addMethod/index.js
+++ b/lib/addMethod/index.js
@@ -189,7 +189,7 @@ module.exports = function (methodName, config) {
         logger.info(methodName+': running `afterSuccess` hook');
         globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
       }, function (err) {
-        logger.info(methodName+': running `afterFailure` hook', err);
+        logger.info(methodName+': running `afterFailure` hook', _.omit(err, ['response']));
         var payload = ( err.payload ? err.payload : err ),
             response = ( err.response ? err.response : {} );
         globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);


### PR DESCRIPTION
Got rid of the excessive quantity of logs we'd get when running connectors in dev mode