### PR TITLE
Ch10939/f/afterHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ threadneedle.getLists({
 
 * [addMethod](#addmethod)
 * [global](#global)
-* [SOAP Mode](#SOAP Mode)
+* [SOAP Mode](#soap-mode)
 
 
 ## addMethod
 
 The vast majority of threadneedle focuses around this singular method. Whenever you run `addMethod`, you're adding another method to the core `threadneedle` object.
+
+### addMethod - REST template
 
 You can declare template-style parameters to be passed into specific fields, using Mustache-style templating.
 
@@ -67,9 +69,10 @@ Parameters are:
 * [expects](#expects)
 * [notExpects](#notexpects)
 * [before](#before)
-* [beforeRequest](#beforeRequest)
+* [beforeRequest](#beforerequest)
 * [afterSuccess](#aftersuccess)
 * [afterFailure](#afterfailure)
+* [afterHeaders](#afterheaders)
 
 `addMethod` uses JavaScript promises (using [When.js](https://github.com/cujojs/when)), which allows for the chaining of multiple API calls together, and smart error handling.
 
@@ -271,7 +274,7 @@ Runs **before** any templating or requests.
 }
 ```
 
-## beforeRequest
+### beforeRequest
 
 If you'd like to do some final checks and tweaks **before** the actual request is made, but **after**
 all parameters have been templated, use this method.
@@ -334,9 +337,50 @@ Sometimes you'll want to modify the failure message in some way. You can do
 }
 ```
 
+### afterHeaders
+
+Sometimes you'll want to modify the response headers in some way. You can do
+
+```js
+{
+  method: 'get',
+  url: 'https://{{dc}}.api.mailchimp.com/2.0/users?apikey={{apiKey}}',
+  expects: 200,
+  afterHeaders: function (error, params, body, res) {
+    return {
+        operation: 'cleanup_op',
+        data: {
+            abc: '123'
+        }
+    };
+
+    // You can also return a promise to do async logic. It should resolve
+    // with the header object.
+  }
+}
+```
+`afterHeaders` must always return an object, else it will be ignored.
+
+The parameters are:
+- error - this will be null for a resolving afterSuccess, else it will contain the error
+- params
+- body
+- res
+
+**Note:** if afterHeaders rejects/errors, this error will take precedence over any other error and will form the `body` part of the response. Also, the local `afterHeaders` will merge with the global one if provided, with local object taking precedence.
 
 
-### Function inputs
+### addMethod - REST template - response
+A method which runs a `REST template` will always return the response in a particular format:
+```json
+{
+    "headers": {},
+    "body":  {}
+}
+```
+The `body` will contain the main response or error, while `headers` is available for specifying additional meta data via `afterHeaders`.
+
+### addMethod - function
 
 Sometimes you'll have a method which isn't REST-based, or you'd like to use a third-party wrapper.
 
@@ -569,6 +613,25 @@ A good example use-case here is a generic error handler for invalid status codes
 * Shopify - a `429` status code means the API limits have been exceeded
 
 Rather than write the same code in every method, use this global method.
+
+```js
+{
+  afterFailure: function (err, params) {
+    if (err.response.statusCode === 429) {
+      err.code = 'call_limit_exceeded';
+    }
+
+    // You can also return a promise which should resolve having modified the error
+  }
+}
+```
+
+### afterHeaders
+
+Runs after a method runs successfully, immediately **before** the `afterHeaders` function
+of the individual method.
+
+If there is meta data that needs to be specified with every `REST template` method, this is a good place to set it.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -690,3 +690,6 @@ The following fields are pretty much the same as the REST versions, unless expli
 - `baseUrl`
 - `url`
 - `query`
+
+### addMethod - SOAP template - response
+The response format is identical to the REST template response. 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ The parameters correspond directly to those for [addMethod](#addmethod):
 * [beforeRequest](#beforerequest-1)
 * [afterSuccess](#aftersuccess-1)
 * [afterFailure](#afterfailure-1)
+* [afterHeaders](#afterHeaders-1)
 
 Example usage:
 
@@ -682,6 +683,7 @@ The following fields are pretty much the same as the REST versions, unless expli
 - `beforeRequest`
 - `afterSuccess`
 - `afterFailure`
+- `afterHeaders`
 
 
 **Note**: The following are not supported and will be ignored:

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -88,7 +88,7 @@ module.exports = function (methodName, config) {
                     reject(formatResponse(headers, error));
                 },
                 function (err) {
-                    reject(formatResponse({}, err));
+                    reject(formatResponse({}, err || error));
                 }
             );
 

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -193,15 +193,72 @@ module.exports = function (methodName, config) {
       })
 
       // Handle the after success and failure messages
-      .done(function (result) {
-        logger.info(methodName+': running `afterSuccess` hook');
-        globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
-      }, function (err) {
-        logger.info(methodName+': running `afterFailure` hook', err);
-        var payload = ( err.payload ? err.payload : err ),
-            response = ( err.response ? err.response : {} );
-        globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
-      });
+
+      .done(
+      	function (result) {
+
+            logger.info(methodName+': running `afterSuccess` hook');
+            globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
+
+            .then(function (body) {
+                // return body;
+                return when.promise(function (hResolve, hReject) {
+
+
+                    globalize.afterHeader.call(threadneedle, config, result.body, params, result.response)
+
+                    .then(function (header) {
+                        return {
+                            header: header || {},
+                            body: body
+                        };
+                    })
+
+                    .done(hResolve, hReject);
+
+                });
+
+            })
+
+            .done(resolve, reject);
+
+      	},
+      	function (err) {
+      		logger.info(methodName + ': running `afterFailure` hook', err);
+      		var payload = (err.payload ? err.payload : err),
+      			response = (err.response ? err.response : {});
+      		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
+      	}
+      );
+
+      // .then(
+      //   function (result) {
+      //     logger.info(methodName+': running `afterSuccess` hook');
+      //     return when.promise(function (sResolve, sReject) {
+      //         globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(sResolve, sReject);
+      //     });
+      //   },
+      //   function (err) {
+      //     logger.info(methodName+': running `afterFailure` hook', err);
+      //     var payload = ( err.payload ? err.payload : err ),
+      //         response = ( err.response ? err.response : {} );
+      //     return when.promise(function (fResolve, fReject) {
+      //         globalize.afterFailure.call(threadneedle, config, payload, params, response).done(fResolve, fResolve);
+      //     });
+      //   }
+      // )
+      //
+      // .done(resolve, reject);
+
+      // .done(function (result) {
+      //   logger.info(methodName+': running `afterSuccess` hook');
+      //   globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
+      // }, function (err) {
+      //   logger.info(methodName+': running `afterFailure` hook', err);
+      //   var payload = ( err.payload ? err.payload : err ),
+      //       response = ( err.response ? err.response : {} );
+      //   globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
+      // });
 
     });
   };

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -94,74 +94,74 @@ module.exports = function (methodName, config) {
 
         }
 
-      // Method, always lowercased
-      var method = config.method.toLowerCase();
+        // Method, always lowercased
+        var method = config.method.toLowerCase();
 
-      // Kick off that promise chain
-      when()
+        // Kick off that promise chain
+        when()
 
-      // Run a `before` if set on the params.
-      .then(function () {
-        logger.info('Running method `'+methodName+'` `before`.');
-        return globalize.before.call(threadneedle, config, params);
-      })
+        // Run a `before` if set on the params.
+        .then(function () {
+            logger.info('Running method `'+methodName+'` `before`.');
+            return globalize.before.call(threadneedle, config, params);
+        })
 
-      // Set a bunch of local variables, formatted and templated
-      .then(function (result) {
-        params = result;
+        // Set a bunch of local variables, formatted and templated
+        .then(function (result) {
+            params = result;
 
-        logger.info(methodName+': substituting parameters');
+            logger.info(methodName+': substituting parameters');
 
-        // Add a temp file parameter for file handling operations
-        if (config.fileHandler === true) {
-          params.temp_file = '/tmp/'+guid();
-        }
+            // Add a temp file parameter for file handling operations
+            if (config.fileHandler === true) {
+              params.temp_file = '/tmp/'+guid();
+            }
 
-        // The URL endpoint. Query parameters allowed from here.
-        var url = globalize.baseUrl.call(threadneedle, config, params);
-        // var url = globalize.call(threadneedle, config.globals, 'url', config, params);
+            // The URL endpoint. Query parameters allowed from here.
+            var url = globalize.baseUrl.call(threadneedle, config, params);
+            // var url = globalize.call(threadneedle, config.globals, 'url', config, params);
 
-        // Add query parameters intelligently, without conflicting from query parameters
-        // already specified in the URL.
-        var query = globalize.object.call(threadneedle, 'query', config, params);
-        _.each(query, function (value, key) {
-          if (_.isArray(value) && value.length > 0) {
-            value = value.join(',');
-          }
-          if (!_.isUndefined(value) && !(_.isString(value) && value === '')) {
-            url = setParam(url, key, value);
-          }
-        });
+            // Add query parameters intelligently, without conflicting from query parameters
+            // already specified in the URL.
+            var query = globalize.object.call(threadneedle, 'query', config, params);
+            _.each(query, function (value, key) {
+              if (_.isArray(value) && value.length > 0) {
+                value = value.join(',');
+              }
+              if (!_.isUndefined(value) && !(_.isString(value) && value === '')) {
+                url = setParam(url, key, value);
+              }
+            });
 
-        // The request options, substituted
-        var options = globalize.object.call(threadneedle, 'options', config, params);
+            // The request options, substituted
+            var options = globalize.object.call(threadneedle, 'options', config, params);
 
-        // Post/put/delete data
-        var data;
-        switch (method) {
-            case 'get':
-            case 'head':
-                break;
-            default:
-                data = globalize.object.call(threadneedle, 'data', config, params);
-        }
+            // Post/put/delete data
+            var data;
+            switch (method) {
+                case 'get':
+                case 'head':
+                    break;
+                default:
+                    data = globalize.object.call(threadneedle, 'data', config, params);
+            }
 
-        return {
-          url: url,
-          data: data,
-          options: options,
-          method: method
-        };
-      })
+            return {
+              url: url,
+              data: data,
+              options: options,
+              method: method
+            };
+        })
 
-      // Run the `beforeRequest`
-      .then(function (request) {
-        logger.info(methodName+': running `beforeRequest` hook');
-        return globalize.beforeRequest.call(threadneedle, config, request, params);
-      })
+        // Run the `beforeRequest`
+        .then(function (request) {
+            logger.info(methodName+': running `beforeRequest` hook');
+            return globalize.beforeRequest.call(threadneedle, config, request, params);
+        })
 
-      // Run the actual request
-      .then(function (request) {
+        // Run the actual request
+        .then(function (request) {
           return when.promise(function(resolve, reject) {
 
             	var handleResponse = function(err, res, body) {
@@ -231,13 +231,12 @@ module.exports = function (methodName, config) {
             			needle[method](request.url, request.data, request.options, handleResponse);
             	}
 
-        });
-      })
+          });
+        })
 
-      // Handle the after success and failure messages
-
-      .done(
-      	function (result) {
+        // Handle the after success and failure messages
+        .done(
+        	function (result) {
 
             logger.info(methodName+': running `afterSuccess` hook');
             globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
@@ -247,266 +246,23 @@ module.exports = function (methodName, config) {
                 function (error) { afterHeadersReject(error, result.body, result.response); }
             );
 
-      	},
-      	function (err) {
+        	},
+        	function (err) {
 
             var payload = (err.payload ? err.payload : err),
-      			response = (err.response ? err.response : {});
+        			response = (err.response ? err.response : {});
 
             function rejectAfterHeaders (error) { afterHeadersReject(error, payload, response); }
 
-      		logger.info(methodName + ': running `afterFailure` hook', err);
-      		globalize.afterFailure.call(threadneedle, config, payload, params, response)
+        		logger.info(methodName + ': running `afterFailure` hook', err);
+        		globalize.afterFailure.call(threadneedle, config, payload, params, response)
             .done(rejectAfterHeaders, rejectAfterHeaders);
 
-      	}
-      );
+        	}
+        );
 
     });
 
-    // return when.promise(function (resolve, reject) {
-    //
-    //   // Method, always lowercased
-    //   var method = config.method.toLowerCase();
-    //
-    //   // Kick off that promise chain
-    //   when()
-    //
-    //   // Run a `before` if set on the params.
-    //   .then(function () {
-    //     logger.info('Running method `'+methodName+'` `before`.');
-    //     return globalize.before.call(threadneedle, config, params);
-    //   })
-    //
-    //   // Set a bunch of local variables, formatted and templated
-    //   .then(function (result) {
-    //     params = result;
-    //
-    //     logger.info(methodName+': substituting parameters');
-    //
-    //     // Add a temp file parameter for file handling operations
-    //     if (config.fileHandler === true) {
-    //       params.temp_file = '/tmp/'+guid();
-    //     }
-    //
-    //     // The URL endpoint. Query parameters allowed from here.
-    //     var url = globalize.baseUrl.call(threadneedle, config, params);
-    //     // var url = globalize.call(threadneedle, config.globals, 'url', config, params);
-    //
-    //     // Add query parameters intelligently, without conflicting from query parameters
-    //     // already specified in the URL.
-    //     var query = globalize.object.call(threadneedle, 'query', config, params);
-    //     _.each(query, function (value, key) {
-    //       if (_.isArray(value) && value.length > 0) {
-    //         value = value.join(',');
-    //       }
-    //       if (!_.isUndefined(value) && !(_.isString(value) && value === '')) {
-    //         url = setParam(url, key, value);
-    //       }
-    //     });
-    //
-    //     // The request options, substituted
-    //     var options = globalize.object.call(threadneedle, 'options', config, params);
-    //
-    //     // Post/put/delete data
-    //     var data;
-    //     switch (method) {
-    //         case 'get':
-    //         case 'head':
-    //             break;
-    //         default:
-    //             data = globalize.object.call(threadneedle, 'data', config, params);
-    //     }
-    //
-    //     return {
-    //       url: url,
-    //       data: data,
-    //       options: options,
-    //       method: method
-    //     };
-    //   })
-    //
-    //   // Run the `beforeRequest`
-    //   .then(function (request) {
-    //     logger.info(methodName+': running `beforeRequest` hook');
-    //     return globalize.beforeRequest.call(threadneedle, config, request, params);
-    //   })
-    //
-    //   // Run the actual request
-    //   .then(function (request) {
-    //       return when.promise(function(resolve, reject) {
-    //
-    //         	var handleResponse = function(err, res, body) {
-    //
-    //         		function handleReject(payload) {
-    //         			return reject({
-    //         				payload: payload,
-    //         				response: res
-    //         			});
-    //         		}
-    //
-    //         		if (err) {
-    //
-    //         			// Specifically handle socket hang ups nicely
-    //         			if (_.isError(err) && err.message === 'socket hang up') {
-    //         				return handleReject( {
-    //         					code: 'api_timeout',
-    //         					response:
-    //         					{},
-    //         					message: 'API call timeout. Looks like the API you\'re calling is having a wobble. Please try again later.'
-    //         				});
-    //         			}
-    //
-    //         			else {
-    //         				return handleReject(err);
-    //         			}
-    //
-    //         		} else {
-    //
-    //         			logger.info(methodName + ': got response', res.statusCode, JSON.stringify(body));
-    //
-    //         			var validationError;
-    //
-    //         			// Validate `expects`
-    //         			var expects = globalize.expects.call(threadneedle, config);
-    //         			validationError = validateExpects(res, expects);
-    //         			if (validationError){
-    //         				return handleReject(validationError);
-    //         			}
-    //
-    //         			// Validate `notExpects`
-    //         			var notExpects = globalize.notExpects.call(threadneedle, config);
-    //         			validationError = validateNotExpects(res, notExpects);
-    //         			if (validationError){
-    //         				return handleReject(validationError);
-    //         			}
-    //
-    //         			// We're valid!
-    //         			resolve({
-    //         				body: body,
-    //         				response: res
-    //         			});
-    //
-    //         		}
-    //         	};
-    //
-    //         	// console.log(options);
-    //         	logger.info(methodName + ': running ' + method + ' request', request);
-    //
-    //         	// Run a different method for get to not include data
-    //         	switch (method) {
-    //         		case 'get':
-    //         		case 'head':
-    //         			needle[method](request.url, request.options, handleResponse);
-    //         			break;
-    //         		default:
-    //         			needle[method](request.url, request.data, request.options, handleResponse);
-    //         	}
-    //
-    //     });
-    //   })
-    //
-    //   // Handle the after success and failure messages
-    //
-    //   .done(
-    //   	function (result) {
-    //
-    //         logger.info(methodName+': running `afterSuccess` hook');
-    //         globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
-    //
-    //         .done(
-    //             function (body) {
-    //
-    //                 logger.info(methodName+': running `afterHeader` hook');
-    //                 globalize.afterHeaders.call(threadneedle, config, null, body, params, result.response)
-    //
-    //                 .then(function (header) {
-    //                     return {
-    //                         header: ( _.isPlainObject(header) ? header : {} ),
-    //                         body: body
-    //                     };
-    //                 })
-    //
-    //                 .done(resolve, reject);
-    //
-    //             },
-    //             function (error) {
-    //
-    //                 logger.info(methodName+': running `afterHeader` hook');
-    //                 globalize.afterHeaders.call(threadneedle, config, error, result.body, params, result.response)
-    //
-    //                 .then(function (header) {
-    //                     return {
-    //                         header: ( _.isPlainObject(header) ? header : {} ),
-    //                         body: body
-    //                     };
-    //                 })
-    //
-    //                 .done(reject, reject);
-    //
-    //             }
-    //         );
-    //
-    //   	},
-    //   	function (err) {
-    //
-    //         var payload = (err.payload ? err.payload : err),
-    //   			response = (err.response ? err.response : {});
-    //
-    //         //TODO: this logic
-    //         function rejectAfterHeaders (error) {
-    //
-    //             logger.info(methodName+': running `afterHeader` hook');
-    //             globalize.afterHeaders.call(threadneedle, config, error, payload, params, response)
-    //
-    //             .then(function (header) {
-    //                 return {
-    //                     header: ( _.isPlainObject(header) ? header : {} ),
-    //                     body: error
-    //                 };
-    //             })
-    //
-    //             .done(reject, reject);
-    //
-    //         }
-    //
-    //   		logger.info(methodName + ': running `afterFailure` hook', err);
-    //   		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(rejectAfterHeaders, rejectAfterHeaders);
-    //   		// globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
-    //
-    //   	}
-    //   );
-    //
-    //   // .then(
-    //   //   function (result) {
-    //   //     logger.info(methodName+': running `afterSuccess` hook');
-    //   //     return when.promise(function (sResolve, sReject) {
-    //   //         globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(sResolve, sReject);
-    //   //     });
-    //   //   },
-    //   //   function (err) {
-    //   //     logger.info(methodName+': running `afterFailure` hook', err);
-    //   //     var payload = ( err.payload ? err.payload : err ),
-    //   //         response = ( err.response ? err.response : {} );
-    //   //     return when.promise(function (fResolve, fReject) {
-    //   //         globalize.afterFailure.call(threadneedle, config, payload, params, response).done(fResolve, fResolve);
-    //   //     });
-    //   //   }
-    //   // )
-    //   //
-    //   // .done(resolve, reject);
-    //
-    //   // .done(function (result) {
-    //   //   logger.info(methodName+': running `afterSuccess` hook');
-    //   //   globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
-    //   // }, function (err) {
-    //   //   logger.info(methodName+': running `afterFailure` hook', err);
-    //   //   var payload = ( err.payload ? err.payload : err ),
-    //   //       response = ( err.response ? err.response : {} );
-    //   //   globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
-    //   // });
-    //
-    // });
   };
 
 };

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -52,23 +52,23 @@ module.exports = function (methodName, config) {
 
     return when.promise(function (resolve, reject) {
 
-        //The format of the response should always be an object with header and body
-        function formatResponse (header, body) {
+        //The format of the response should always be an object with headers and body
+        function formatResponse (headers, body) {
             return {
-                header: ( _.isPlainObject(header) ? header : {} ),
+                headers: ( _.isPlainObject(headers) ? headers : {} ),
                 body: body
             };
         }
 
         //Handle afterHeader for resolving
-        function afterHeaderResolve (body, result) {
+        function afterHeadersResolve (body, result) {
 
-            logger.info(methodName+': running `afterHeader` hook');
-            globalize.afterHeader.call(threadneedle, config, null, body, params, result.response)
+            logger.info(methodName+': running `afterHeaders` hook');
+            globalize.afterHeaders.call(threadneedle, config, null, body, params, result.response)
 
             .done(
-                function (header) {
-                    resolve(formatResponse(header, body));
+                function (headers) {
+                    resolve(formatResponse(headers, body));
                 },
                 function (error) {
                     reject(formatResponse({}, error));
@@ -78,14 +78,14 @@ module.exports = function (methodName, config) {
         }
 
         //Handle afterHeader for rejecting
-        function afterHeaderReject (error, payload, response) {
+        function afterHeadersReject (error, payload, response) {
 
-            logger.info(methodName+': running `afterHeader` hook');
-            globalize.afterHeader.call(threadneedle, config, error, payload, params, response)
+            logger.info(methodName+': running `afterHeaders` hook');
+            globalize.afterHeaders.call(threadneedle, config, error, payload, params, response)
 
             .done(
-                function (header) {
-                    reject(formatResponse(header, error));
+                function (headers) {
+                    reject(formatResponse(headers, error));
                 },
                 function (err) {
                     reject(formatResponse({}, err));
@@ -243,8 +243,8 @@ module.exports = function (methodName, config) {
             globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
 
             .done(
-                function (body) { afterHeaderResolve(body, result); },
-                function (error) { afterHeaderReject(error, result.body, result.response); }
+                function (body) { afterHeadersResolve(body, result); },
+                function (error) { afterHeadersReject(error, result.body, result.response); }
             );
 
       	},
@@ -253,11 +253,11 @@ module.exports = function (methodName, config) {
             var payload = (err.payload ? err.payload : err),
       			response = (err.response ? err.response : {});
 
-            function rejectAfterHeader (error) { afterHeaderReject(error, payload, response); }
+            function rejectAfterHeaders (error) { afterHeadersReject(error, payload, response); }
 
       		logger.info(methodName + ': running `afterFailure` hook', err);
       		globalize.afterFailure.call(threadneedle, config, payload, params, response)
-            .done(rejectAfterHeader, rejectAfterHeader);
+            .done(rejectAfterHeaders, rejectAfterHeaders);
 
       	}
       );
@@ -418,7 +418,7 @@ module.exports = function (methodName, config) {
     //             function (body) {
     //
     //                 logger.info(methodName+': running `afterHeader` hook');
-    //                 globalize.afterHeader.call(threadneedle, config, null, body, params, result.response)
+    //                 globalize.afterHeaders.call(threadneedle, config, null, body, params, result.response)
     //
     //                 .then(function (header) {
     //                     return {
@@ -433,7 +433,7 @@ module.exports = function (methodName, config) {
     //             function (error) {
     //
     //                 logger.info(methodName+': running `afterHeader` hook');
-    //                 globalize.afterHeader.call(threadneedle, config, error, result.body, params, result.response)
+    //                 globalize.afterHeaders.call(threadneedle, config, error, result.body, params, result.response)
     //
     //                 .then(function (header) {
     //                     return {
@@ -454,10 +454,10 @@ module.exports = function (methodName, config) {
     //   			response = (err.response ? err.response : {});
     //
     //         //TODO: this logic
-    //         function rejectAfterHeader (error) {
+    //         function rejectAfterHeaders (error) {
     //
     //             logger.info(methodName+': running `afterHeader` hook');
-    //             globalize.afterHeader.call(threadneedle, config, error, payload, params, response)
+    //             globalize.afterHeaders.call(threadneedle, config, error, payload, params, response)
     //
     //             .then(function (header) {
     //                 return {
@@ -471,7 +471,7 @@ module.exports = function (methodName, config) {
     //         }
     //
     //   		logger.info(methodName + ': running `afterFailure` hook', err);
-    //   		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(rejectAfterHeader, rejectAfterHeader);
+    //   		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(rejectAfterHeaders, rejectAfterHeaders);
     //   		// globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
     //
     //   	}

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -58,7 +58,7 @@ module.exports = function (methodName, config) {
         };
     }
 
-    return when.promise(function (resolve, reject) {    
+    return when.promise(function (resolve, reject) {
 
         //Handle afterHeader for resolving
         function afterHeadersResolve (body, result) {

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -204,7 +204,7 @@ module.exports = function (methodName, config) {
                 // return body;
                 return when.promise(function (hResolve, hReject) {
 
-
+                    logger.info(methodName+': running `afterHeader` hook');
                     globalize.afterHeader.call(threadneedle, config, result.body, params, result.response)
 
                     .then(function (header) {

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -36,6 +36,14 @@ module.exports = function (methodName, config) {
   // on app startup;
   validateInput.call(this, methodName, config);
 
+  //The format of the response should always be an object with headers and body
+  function formatResponse (headers, body) {
+      return {
+          headers: ( _.isPlainObject(headers) ? headers : {} ),
+          body: body
+      };
+  }
+
   // Create the method
   threadneedle[methodName] = function (params) {
 
@@ -47,16 +55,16 @@ module.exports = function (methodName, config) {
     */
     if (_.isFunction(config)) {
       logger.info(methodName+': Running method function.');
-      return when(config.call(threadneedle, params));
+      return when.promise(function (resolve, reject) {
+         when(config.call(threadneedle, params))
+         .done(
+             function (body) { resolve(formatResponse({}, body)); },
+             function (err) { resolve(formatResponse({}, err)); }
+         );
+      });
     }
 
-    //The format of the response should always be an object with headers and body
-    function formatResponse (headers, body) {
-        return {
-            headers: ( _.isPlainObject(headers) ? headers : {} ),
-            body: body
-        };
-    }
+
 
     return when.promise(function (resolve, reject) {
 

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -52,6 +52,48 @@ module.exports = function (methodName, config) {
 
     return when.promise(function (resolve, reject) {
 
+        //The format of the response should always be an object with header and body
+        function formatResponse (header, body) {
+            return {
+                header: ( _.isPlainObject(header) ? header : {} ),
+                body: body
+            };
+        }
+
+        //Handle afterHeader for resolving
+        function afterHeaderResolve (body, result) {
+
+            logger.info(methodName+': running `afterHeader` hook');
+            globalize.afterHeader.call(threadneedle, config, null, body, params, result.response)
+
+            .done(
+                function (header) {
+                    resolve(formatResponse(header, body));
+                },
+                function (error) {
+                    reject(formatResponse({}, error));
+                }
+            );
+
+        }
+
+        //Handle afterHeader for rejecting
+        function afterHeaderReject (error, payload, response) {
+
+            logger.info(methodName+': running `afterHeader` hook');
+            globalize.afterHeader.call(threadneedle, config, error, payload, params, response)
+
+            .done(
+                function (header) {
+                    reject(formatResponse(header, error));
+                },
+                function (err) {
+                    reject(formatResponse({}, err));
+                }
+            );
+
+        }
+
       // Method, always lowercased
       var method = config.method.toLowerCase();
 
@@ -201,36 +243,8 @@ module.exports = function (methodName, config) {
             globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
 
             .done(
-                function (body) {
-
-                    logger.info(methodName+': running `afterHeader` hook');
-                    globalize.afterHeader.call(threadneedle, config, null, body, params, result.response)
-
-                    .then(function (header) {
-                        return {
-                            header: ( _.isPlainObject(header) ? header : {} ),
-                            body: body
-                        };
-                    })
-
-                    .done(resolve, reject);
-
-                },
-                function (error) {
-
-                    logger.info(methodName+': running `afterHeader` hook');
-                    globalize.afterHeader.call(threadneedle, config, error, result.body, params, result.response)
-
-                    .then(function (header) {
-                        return {
-                            header: ( _.isPlainObject(header) ? header : {} ),
-                            body: body
-                        };
-                    })
-
-                    .done(reject, reject);
-
-                }
+                function (body) { afterHeaderResolve(body, result); },
+                function (error) { afterHeaderReject(error, result.body, result.response); }
             );
 
       	},
@@ -239,60 +253,260 @@ module.exports = function (methodName, config) {
             var payload = (err.payload ? err.payload : err),
       			response = (err.response ? err.response : {});
 
-            //TODO: this logic
-            function rejectAfterHeader (error) {
-
-                logger.info(methodName+': running `afterHeader` hook');
-                globalize.afterHeader.call(threadneedle, config, error, payload, params, response)
-
-                .then(function (header) {
-                    return {
-                        header: ( _.isPlainObject(header) ? header : {} ),
-                        body: error
-                    };
-                })
-
-                .done(reject, reject);
-
-            }
+            function rejectAfterHeader (error) { afterHeaderReject(error, payload, response); }
 
       		logger.info(methodName + ': running `afterFailure` hook', err);
-      		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(rejectAfterHeader, rejectAfterHeader);
-      		// globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
+      		globalize.afterFailure.call(threadneedle, config, payload, params, response)
+            .done(rejectAfterHeader, rejectAfterHeader);
 
       	}
       );
 
-      // .then(
-      //   function (result) {
-      //     logger.info(methodName+': running `afterSuccess` hook');
-      //     return when.promise(function (sResolve, sReject) {
-      //         globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(sResolve, sReject);
-      //     });
-      //   },
-      //   function (err) {
-      //     logger.info(methodName+': running `afterFailure` hook', err);
-      //     var payload = ( err.payload ? err.payload : err ),
-      //         response = ( err.response ? err.response : {} );
-      //     return when.promise(function (fResolve, fReject) {
-      //         globalize.afterFailure.call(threadneedle, config, payload, params, response).done(fResolve, fResolve);
-      //     });
-      //   }
-      // )
-      //
-      // .done(resolve, reject);
-
-      // .done(function (result) {
-      //   logger.info(methodName+': running `afterSuccess` hook');
-      //   globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
-      // }, function (err) {
-      //   logger.info(methodName+': running `afterFailure` hook', err);
-      //   var payload = ( err.payload ? err.payload : err ),
-      //       response = ( err.response ? err.response : {} );
-      //   globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
-      // });
-
     });
+
+    // return when.promise(function (resolve, reject) {
+    //
+    //   // Method, always lowercased
+    //   var method = config.method.toLowerCase();
+    //
+    //   // Kick off that promise chain
+    //   when()
+    //
+    //   // Run a `before` if set on the params.
+    //   .then(function () {
+    //     logger.info('Running method `'+methodName+'` `before`.');
+    //     return globalize.before.call(threadneedle, config, params);
+    //   })
+    //
+    //   // Set a bunch of local variables, formatted and templated
+    //   .then(function (result) {
+    //     params = result;
+    //
+    //     logger.info(methodName+': substituting parameters');
+    //
+    //     // Add a temp file parameter for file handling operations
+    //     if (config.fileHandler === true) {
+    //       params.temp_file = '/tmp/'+guid();
+    //     }
+    //
+    //     // The URL endpoint. Query parameters allowed from here.
+    //     var url = globalize.baseUrl.call(threadneedle, config, params);
+    //     // var url = globalize.call(threadneedle, config.globals, 'url', config, params);
+    //
+    //     // Add query parameters intelligently, without conflicting from query parameters
+    //     // already specified in the URL.
+    //     var query = globalize.object.call(threadneedle, 'query', config, params);
+    //     _.each(query, function (value, key) {
+    //       if (_.isArray(value) && value.length > 0) {
+    //         value = value.join(',');
+    //       }
+    //       if (!_.isUndefined(value) && !(_.isString(value) && value === '')) {
+    //         url = setParam(url, key, value);
+    //       }
+    //     });
+    //
+    //     // The request options, substituted
+    //     var options = globalize.object.call(threadneedle, 'options', config, params);
+    //
+    //     // Post/put/delete data
+    //     var data;
+    //     switch (method) {
+    //         case 'get':
+    //         case 'head':
+    //             break;
+    //         default:
+    //             data = globalize.object.call(threadneedle, 'data', config, params);
+    //     }
+    //
+    //     return {
+    //       url: url,
+    //       data: data,
+    //       options: options,
+    //       method: method
+    //     };
+    //   })
+    //
+    //   // Run the `beforeRequest`
+    //   .then(function (request) {
+    //     logger.info(methodName+': running `beforeRequest` hook');
+    //     return globalize.beforeRequest.call(threadneedle, config, request, params);
+    //   })
+    //
+    //   // Run the actual request
+    //   .then(function (request) {
+    //       return when.promise(function(resolve, reject) {
+    //
+    //         	var handleResponse = function(err, res, body) {
+    //
+    //         		function handleReject(payload) {
+    //         			return reject({
+    //         				payload: payload,
+    //         				response: res
+    //         			});
+    //         		}
+    //
+    //         		if (err) {
+    //
+    //         			// Specifically handle socket hang ups nicely
+    //         			if (_.isError(err) && err.message === 'socket hang up') {
+    //         				return handleReject( {
+    //         					code: 'api_timeout',
+    //         					response:
+    //         					{},
+    //         					message: 'API call timeout. Looks like the API you\'re calling is having a wobble. Please try again later.'
+    //         				});
+    //         			}
+    //
+    //         			else {
+    //         				return handleReject(err);
+    //         			}
+    //
+    //         		} else {
+    //
+    //         			logger.info(methodName + ': got response', res.statusCode, JSON.stringify(body));
+    //
+    //         			var validationError;
+    //
+    //         			// Validate `expects`
+    //         			var expects = globalize.expects.call(threadneedle, config);
+    //         			validationError = validateExpects(res, expects);
+    //         			if (validationError){
+    //         				return handleReject(validationError);
+    //         			}
+    //
+    //         			// Validate `notExpects`
+    //         			var notExpects = globalize.notExpects.call(threadneedle, config);
+    //         			validationError = validateNotExpects(res, notExpects);
+    //         			if (validationError){
+    //         				return handleReject(validationError);
+    //         			}
+    //
+    //         			// We're valid!
+    //         			resolve({
+    //         				body: body,
+    //         				response: res
+    //         			});
+    //
+    //         		}
+    //         	};
+    //
+    //         	// console.log(options);
+    //         	logger.info(methodName + ': running ' + method + ' request', request);
+    //
+    //         	// Run a different method for get to not include data
+    //         	switch (method) {
+    //         		case 'get':
+    //         		case 'head':
+    //         			needle[method](request.url, request.options, handleResponse);
+    //         			break;
+    //         		default:
+    //         			needle[method](request.url, request.data, request.options, handleResponse);
+    //         	}
+    //
+    //     });
+    //   })
+    //
+    //   // Handle the after success and failure messages
+    //
+    //   .done(
+    //   	function (result) {
+    //
+    //         logger.info(methodName+': running `afterSuccess` hook');
+    //         globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
+    //
+    //         .done(
+    //             function (body) {
+    //
+    //                 logger.info(methodName+': running `afterHeader` hook');
+    //                 globalize.afterHeader.call(threadneedle, config, null, body, params, result.response)
+    //
+    //                 .then(function (header) {
+    //                     return {
+    //                         header: ( _.isPlainObject(header) ? header : {} ),
+    //                         body: body
+    //                     };
+    //                 })
+    //
+    //                 .done(resolve, reject);
+    //
+    //             },
+    //             function (error) {
+    //
+    //                 logger.info(methodName+': running `afterHeader` hook');
+    //                 globalize.afterHeader.call(threadneedle, config, error, result.body, params, result.response)
+    //
+    //                 .then(function (header) {
+    //                     return {
+    //                         header: ( _.isPlainObject(header) ? header : {} ),
+    //                         body: body
+    //                     };
+    //                 })
+    //
+    //                 .done(reject, reject);
+    //
+    //             }
+    //         );
+    //
+    //   	},
+    //   	function (err) {
+    //
+    //         var payload = (err.payload ? err.payload : err),
+    //   			response = (err.response ? err.response : {});
+    //
+    //         //TODO: this logic
+    //         function rejectAfterHeader (error) {
+    //
+    //             logger.info(methodName+': running `afterHeader` hook');
+    //             globalize.afterHeader.call(threadneedle, config, error, payload, params, response)
+    //
+    //             .then(function (header) {
+    //                 return {
+    //                     header: ( _.isPlainObject(header) ? header : {} ),
+    //                     body: error
+    //                 };
+    //             })
+    //
+    //             .done(reject, reject);
+    //
+    //         }
+    //
+    //   		logger.info(methodName + ': running `afterFailure` hook', err);
+    //   		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(rejectAfterHeader, rejectAfterHeader);
+    //   		// globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
+    //
+    //   	}
+    //   );
+    //
+    //   // .then(
+    //   //   function (result) {
+    //   //     logger.info(methodName+': running `afterSuccess` hook');
+    //   //     return when.promise(function (sResolve, sReject) {
+    //   //         globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(sResolve, sReject);
+    //   //     });
+    //   //   },
+    //   //   function (err) {
+    //   //     logger.info(methodName+': running `afterFailure` hook', err);
+    //   //     var payload = ( err.payload ? err.payload : err ),
+    //   //         response = ( err.response ? err.response : {} );
+    //   //     return when.promise(function (fResolve, fReject) {
+    //   //         globalize.afterFailure.call(threadneedle, config, payload, params, response).done(fResolve, fResolve);
+    //   //     });
+    //   //   }
+    //   // )
+    //   //
+    //   // .done(resolve, reject);
+    //
+    //   // .done(function (result) {
+    //   //   logger.info(methodName+': running `afterSuccess` hook');
+    //   //   globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
+    //   // }, function (err) {
+    //   //   logger.info(methodName+': running `afterFailure` hook', err);
+    //   //   var payload = ( err.payload ? err.payload : err ),
+    //   //       response = ( err.response ? err.response : {} );
+    //   //   globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
+    //   // });
+    //
+    // });
   };
 
 };

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -238,25 +238,26 @@ module.exports = function (methodName, config) {
         .done(
         	function (result) {
 
-            logger.info(methodName+': running `afterSuccess` hook');
-            globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
-
-            .done(
-                function (body) { afterHeadersResolve(body, result); },
-                function (error) { afterHeadersReject(error, result.body, result.response); }
-            );
+        		logger.info(methodName + ': running `afterSuccess` hook');
+        		globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
+    			.done(
+    				function (body) { afterHeadersResolve(body, result); },
+    				function (error) { afterHeadersReject(error, result.body, result.response); }
+    			);
 
         	},
         	function (err) {
 
-            var payload = (err.payload ? err.payload : err),
+        		var payload = (err.payload ? err.payload : err),
         			response = (err.response ? err.response : {});
 
-            function rejectAfterHeaders (error) { afterHeadersReject(error, payload, response); }
+        		function rejectAfterHeaders(error) {
+        			afterHeadersReject(error, payload, response);
+        		}
 
         		logger.info(methodName + ': running `afterFailure` hook', err);
         		globalize.afterFailure.call(threadneedle, config, payload, params, response)
-            .done(rejectAfterHeaders, rejectAfterHeaders);
+        		.done(rejectAfterHeaders, rejectAfterHeaders);
 
         	}
         );

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -50,15 +50,15 @@ module.exports = function (methodName, config) {
       return when(config.call(threadneedle, params));
     }
 
-    return when.promise(function (resolve, reject) {
+    //The format of the response should always be an object with headers and body
+    function formatResponse (headers, body) {
+        return {
+            headers: ( _.isPlainObject(headers) ? headers : {} ),
+            body: body
+        };
+    }
 
-        //The format of the response should always be an object with headers and body
-        function formatResponse (headers, body) {
-            return {
-                headers: ( _.isPlainObject(headers) ? headers : {} ),
-                body: body
-            };
-        }
+    return when.promise(function (resolve, reject) {    
 
         //Handle afterHeader for resolving
         function afterHeadersResolve (body, result) {

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -200,11 +200,11 @@ module.exports = function (methodName, config) {
             logger.info(methodName+': running `afterSuccess` hook');
             globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
 
-            .then(function (body) {
-                return when.promise(function (hResolve, hReject) {
+            .done(
+                function (body) {
 
                     logger.info(methodName+': running `afterHeader` hook');
-                    globalize.afterHeader.call(threadneedle, config, result.body, params, result.response)
+                    globalize.afterHeader.call(threadneedle, config, null, body, params, result.response)
 
                     .then(function (header) {
                         return {
@@ -213,19 +213,53 @@ module.exports = function (methodName, config) {
                         };
                     })
 
-                    .done(hResolve, hReject);
+                    .done(resolve, reject);
 
-                });
-            })
+                },
+                function (error) {
 
-            .done(resolve, reject);
+                    logger.info(methodName+': running `afterHeader` hook');
+                    globalize.afterHeader.call(threadneedle, config, error, result.body, params, result.response)
+
+                    .then(function (header) {
+                        return {
+                            header: ( _.isPlainObject(header) ? header : {} ),
+                            body: body
+                        };
+                    })
+
+                    .done(reject, reject);
+
+                }
+            );
 
       	},
       	function (err) {
-      		logger.info(methodName + ': running `afterFailure` hook', err);
-      		var payload = (err.payload ? err.payload : err),
+
+            var payload = (err.payload ? err.payload : err),
       			response = (err.response ? err.response : {});
-      		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
+
+            //TODO: this logic
+            function rejectAfterHeader (error) {
+
+                logger.info(methodName+': running `afterHeader` hook');
+                globalize.afterHeader.call(threadneedle, config, error, payload, params, response)
+
+                .then(function (header) {
+                    return {
+                        header: ( _.isPlainObject(header) ? header : {} ),
+                        body: error
+                    };
+                })
+
+                .done(reject, reject);
+
+            }
+
+      		logger.info(methodName + ': running `afterFailure` hook', err);
+      		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(rejectAfterHeader, rejectAfterHeader);
+      		// globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
+
       	}
       );
 

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -201,7 +201,6 @@ module.exports = function (methodName, config) {
             globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
 
             .then(function (body) {
-                // return body;
                 return when.promise(function (hResolve, hReject) {
 
                     logger.info(methodName+': running `afterHeader` hook');
@@ -209,7 +208,7 @@ module.exports = function (methodName, config) {
 
                     .then(function (header) {
                         return {
-                            header: header || {},
+                            header: ( _.isPlainObject(header) ? header : {} ),
                             body: body
                         };
                     })
@@ -217,7 +216,6 @@ module.exports = function (methodName, config) {
                     .done(hResolve, hReject);
 
                 });
-
             })
 
             .done(resolve, reject);

--- a/lib/addMethod/addMethodSOAP.js
+++ b/lib/addMethod/addMethodSOAP.js
@@ -184,17 +184,16 @@ module.exports = function (methodName, config) {
 			// Handle the after success and failure messages
 			.done(
 				function (result) {
-					logger.info(methodName+': running `afterSuccess` hook');
+					logger.info(methodName + ': running `afterSuccess` hook');
 					globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
-				}, function (err) {
-					logger.info(methodName+': running `afterFailure` hook', err);
-					var payload = ( err.payload ? err.payload : err ),
-					response = ( err.response ? err.response : {} );
+				},
+				function (err) {
+					logger.info(methodName + ': running `afterFailure` hook', err);
+					var payload = (err.payload ? err.payload : err),
+						response = (err.response ? err.response : {});
 					globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
 				}
 			);
-
-
 
 		});
 

--- a/lib/addMethod/addMethodSOAP.js
+++ b/lib/addMethod/addMethodSOAP.js
@@ -31,17 +31,57 @@ module.exports = function (methodName, config) {
 	      return when(config.call(threadneedle, params));
 	    }
 
-		logger.info('Running method `' + methodName + '` `before`.');
-
+		//The format of the response should always be an object with headers and body
+		function formatResponse (headers, body) {
+			return {
+				headers: ( _.isPlainObject(headers) ? headers : {} ),
+				body: body
+			};
+		}
 
 		//Do SOAP stuff
 		return when.promise(function (resolve, reject) {
+
+	        //Handle afterHeader for resolving
+	        function afterHeadersResolve (body, result) {
+
+	            logger.info(methodName+': running `afterHeaders` hook');
+	            globalize.afterHeaders.call(threadneedle, config, null, body, params, result.response)
+
+	            .done(
+	                function (headers) {
+	                    resolve(formatResponse(headers, body));
+	                },
+	                function (error) {
+	                    reject(formatResponse({}, error));
+	                }
+	            );
+
+	        }
+
+	        //Handle afterHeader for rejecting
+	        function afterHeadersReject (error, payload, response) {
+
+	            logger.info(methodName+': running `afterHeaders` hook');
+	            globalize.afterHeaders.call(threadneedle, config, error, payload, params, response)
+
+	            .done(
+	                function (headers) {
+	                    reject(formatResponse(headers, error));
+	                },
+	                function (err) {
+	                    reject(formatResponse({}, err || error));
+	                }
+	            );
+
+	        }
 
 			// Kick off that promise chain
 			when()
 
 			// Run a `before` if set on the params.
 			.then(function () {
+				logger.info('Running method `' + methodName + '` `before`.');
 				return globalize.before.call(threadneedle, config, params);
 			})
 
@@ -183,17 +223,45 @@ module.exports = function (methodName, config) {
 
 			// Handle the after success and failure messages
 			.done(
-				function (result) {
-					logger.info(methodName + ': running `afterSuccess` hook');
-					globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
-				},
-				function (err) {
-					logger.info(methodName + ': running `afterFailure` hook', err);
-					var payload = (err.payload ? err.payload : err),
-						response = (err.response ? err.response : {});
-					globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
-				}
-			);
+	        	function (result) {
+
+	        		logger.info(methodName + ': running `afterSuccess` hook');
+	        		globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
+	    			.done(
+	    				function (body) { afterHeadersResolve(body, result); },
+	    				function (error) { afterHeadersReject(error, result.body, result.response); }
+	    			);
+
+	        	},
+	        	function (err) {
+
+	        		var payload = (err.payload ? err.payload : err),
+	        			response = (err.response ? err.response : {});
+
+	        		function rejectAfterHeaders(error) {
+	        			afterHeadersReject(error, payload, response);
+	        		}
+
+	        		logger.info(methodName + ': running `afterFailure` hook', err);
+	        		globalize.afterFailure.call(threadneedle, config, payload, params, response)
+	        		.done(rejectAfterHeaders, rejectAfterHeaders);
+
+	        	}
+	        );
+
+
+			// .done(
+			// 	function (result) {
+			// 		logger.info(methodName + ': running `afterSuccess` hook');
+			// 		globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
+			// 	},
+			// 	function (err) {
+			// 		logger.info(methodName + ': running `afterFailure` hook', err);
+			// 		var payload = (err.payload ? err.payload : err),
+			// 			response = (err.response ? err.response : {});
+			// 		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
+			// 	}
+			// );
 
 		});
 

--- a/lib/addMethod/addMethodSOAP.js
+++ b/lib/addMethod/addMethodSOAP.js
@@ -249,20 +249,6 @@ module.exports = function (methodName, config) {
 	        	}
 	        );
 
-
-			// .done(
-			// 	function (result) {
-			// 		logger.info(methodName + ': running `afterSuccess` hook');
-			// 		globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response).done(resolve, reject);
-			// 	},
-			// 	function (err) {
-			// 		logger.info(methodName + ': running `afterFailure` hook', err);
-			// 		var payload = (err.payload ? err.payload : err),
-			// 			response = (err.response ? err.response : {});
-			// 		globalize.afterFailure.call(threadneedle, config, payload, params, response).done(reject, reject);
-			// 	}
-			// );
-
 		});
 
 	};

--- a/lib/addMethod/addMethodSOAP.js
+++ b/lib/addMethod/addMethodSOAP.js
@@ -20,6 +20,14 @@ module.exports = function (methodName, config) {
 
 	validateInput.call(this, methodName, config);
 
+	//The format of the response should always be an object with headers and body
+	function formatResponse (headers, body) {
+		return {
+			headers: ( _.isPlainObject(headers) ? headers : {} ),
+			body: body
+		};
+	}
+
 	threadneedle[methodName] = function (params) {
 
 		params = params || {};
@@ -28,16 +36,14 @@ module.exports = function (methodName, config) {
 
 		if (_.isFunction(config)) {
 	      logger.info(methodName+': Running method function.');
-	      return when(config.call(threadneedle, params));
+		  return when.promise(function (resolve, reject) {
+	         when(config.call(threadneedle, params))
+	         .done(
+	             function (body) { resolve(formatResponse({}, body)); },
+	             function (err) { resolve(formatResponse({}, err)); }
+	         );
+	      });
 	    }
-
-		//The format of the response should always be an object with headers and body
-		function formatResponse (headers, body) {
-			return {
-				headers: ( _.isPlainObject(headers) ? headers : {} ),
-				body: body
-			};
-		}
 
 		//Do SOAP stuff
 		return when.promise(function (resolve, reject) {

--- a/lib/addMethod/globalize/afterHeader.js
+++ b/lib/addMethod/globalize/afterHeader.js
@@ -1,0 +1,53 @@
+/*
+ * Run the global and local `afterHeader` method.
+ */
+var when = require('when');
+var _ = require('lodash');
+
+
+module.exports = function (config, body, params, res) {
+	var threadneedle = this;
+	return when.promise(function (resolve, reject) {
+
+        var headers = {};
+
+		when()
+
+		// Run global promise first
+		.then(function () {
+			if (_.isFunction(threadneedle._globalOptions.afterHeader) && !require('./localOnly')(config, 'afterHeader')) {
+				return when(threadneedle._globalOptions.afterHeader(headers, params, body, res));
+			}
+		})
+
+		// Then run the local prmoise
+		.then(function (result) {
+
+			// if result returned, set headers as that. If not,
+			// assume that the `headers` has been manipulated
+			if (result) {
+				headers = result;
+			}
+
+
+			if (_.isFunction(config.afterHeader)) {
+				return when(config.afterHeader(headers, params, body, res));
+			}
+		})
+
+		.then(function (result) {
+
+			// if result returned, set body as that. If not,
+			// assume that the `body` has been manipulated
+			if (result) {
+				headers = result;
+			}
+
+
+			return headers;
+		})
+
+		.done(resolve, reject);
+
+	});
+};

--- a/lib/addMethod/globalize/afterHeader.js
+++ b/lib/addMethod/globalize/afterHeader.js
@@ -5,7 +5,7 @@ var when = require('when');
 var _ = require('lodash');
 
 
-module.exports = function (config, body, params, res) {
+module.exports = function (config, error, body, params, res) {
 	var threadneedle = this;
 	return when.promise(function (resolve, reject) {
 
@@ -16,7 +16,7 @@ module.exports = function (config, body, params, res) {
 		// Run global promise first
 		.then(function () {
 			if (_.isFunction(threadneedle._globalOptions.afterHeader) && !require('./localOnly')(config, 'afterHeader')) {
-				return when(threadneedle._globalOptions.afterHeader(headers, params, body, res));
+				return when(threadneedle._globalOptions.afterHeader(error, headers, params, body, res));
 			}
 		})
 
@@ -31,7 +31,7 @@ module.exports = function (config, body, params, res) {
 
 
 			if (_.isFunction(config.afterHeader)) {
-				return when(config.afterHeader(headers, params, body, res));
+				return when(config.afterHeader(error, headers, params, body, res));
 			}
 		})
 

--- a/lib/addMethod/globalize/afterHeader.js
+++ b/lib/addMethod/globalize/afterHeader.js
@@ -25,7 +25,7 @@ module.exports = function (config, body, params, res) {
 
 			// if result returned, set headers as that. If not,
 			// assume that the `headers` has been manipulated
-			if (result) {
+			if (!_.isUndefined(result)) {
 				headers = result;
 			}
 
@@ -39,7 +39,7 @@ module.exports = function (config, body, params, res) {
 
 			// if result returned, set body as that. If not,
 			// assume that the `body` has been manipulated
-			if (result) {
+			if (!_.isUndefined(result)) {
 				headers = result;
 			}
 

--- a/lib/addMethod/globalize/afterHeaders.js
+++ b/lib/addMethod/globalize/afterHeaders.js
@@ -1,5 +1,5 @@
 /*
- * Run the global and local `afterHeader` method.
+ * Run the global and local `afterHeaders` method.
  */
 var when = require('when');
 var _ = require('lodash');
@@ -15,8 +15,8 @@ module.exports = function (config, error, body, params, res) {
 
 		// Run global promise first
 		.then(function () {
-			if (_.isFunction(threadneedle._globalOptions.afterHeader) && !require('./localOnly')(config, 'afterHeader')) {
-				return when(threadneedle._globalOptions.afterHeader(error, headers, params, body, res));
+			if (_.isFunction(threadneedle._globalOptions.afterHeaders) && !require('./localOnly')(config, 'afterHeaders')) {
+				return when(threadneedle._globalOptions.afterHeaders(error, headers, params, body, res));
 			}
 		})
 
@@ -30,8 +30,8 @@ module.exports = function (config, error, body, params, res) {
 			}
 
 
-			if (_.isFunction(config.afterHeader)) {
-				return when(config.afterHeader(error, headers, params, body, res));
+			if (_.isFunction(config.afterHeaders)) {
+				return when(config.afterHeaders(error, headers, params, body, res));
 			}
 		})
 

--- a/lib/addMethod/globalize/afterHeaders.js
+++ b/lib/addMethod/globalize/afterHeaders.js
@@ -9,14 +9,12 @@ module.exports = function (config, error, body, params, res) {
 	var threadneedle = this;
 	return when.promise(function (resolve, reject) {
 
-        var headers = {};
-
 		when()
 
 		// Run global promise first
 		.then(function () {
 			if (_.isFunction(threadneedle._globalOptions.afterHeaders) && !require('./localOnly')(config, 'afterHeaders')) {
-				return when(threadneedle._globalOptions.afterHeaders(error, headers, params, body, res));
+				return when(threadneedle._globalOptions.afterHeaders(error, params, body, res));
 			}
 		})
 
@@ -24,27 +22,24 @@ module.exports = function (config, error, body, params, res) {
 		.then(function (result) {
 
 			// if result returned, set headers as that. If not,
-			// assume that the `headers` has been manipulated
-			if (!_.isUndefined(result)) {
-				headers = result;
-			}
-
+			// set as blank object
+			result = ( _.isUndefined(result) ? {} : result );
 
 			if (_.isFunction(config.afterHeaders)) {
-				return when(config.afterHeaders(error, headers, params, body, res));
+				return _.defaultsDeep(
+					when(config.afterHeaders(error, params, body, res)),
+					result
+				);
 			}
+
+			return result;
+
 		})
 
 		.then(function (result) {
-
 			// if result returned, set body as that. If not,
-			// assume that the `body` has been manipulated
-			if (!_.isUndefined(result)) {
-				headers = result;
-			}
-
-
-			return headers;
+			// set as blank object
+			return ( _.isUndefined(result) ? {} : result );
 		})
 
 		.done(resolve, reject);

--- a/lib/addMethod/globalize/before.js
+++ b/lib/addMethod/globalize/before.js
@@ -18,7 +18,7 @@ module.exports = function (config, params) {
     // Run global promise first
     .then(function () {
         if (_.isFunction(threadneedle._globalOptions.before) && !require('./localOnly')(config, 'before')) {
-        return when(threadneedle._globalOptions.before(params));
+            return when(threadneedle._globalOptions.before(params));
         }
     })
 

--- a/lib/addMethod/globalize/index.js
+++ b/lib/addMethod/globalize/index.js
@@ -7,6 +7,6 @@ module.exports = {
   expects: require('./expects'),
   notExpects: require('./notExpects'),
   afterSuccess: require('./afterSuccess'),
-  afterHeader: require('./afterHeader'),
+  afterHeaders: require('./afterHeaders'),
   afterFailure: require('./afterFailure')
 };

--- a/lib/addMethod/globalize/index.js
+++ b/lib/addMethod/globalize/index.js
@@ -7,5 +7,6 @@ module.exports = {
   expects: require('./expects'),
   notExpects: require('./notExpects'),
   afterSuccess: require('./afterSuccess'),
+  afterHeader: require('./afterHeader'),
   afterFailure: require('./afterFailure')
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/threadneedle",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A framework for simplifying working with HTTP-based APIs.",
   "main": "lib/index.js",
   "directories": {

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -682,7 +682,7 @@ describe('#addMethodREST', function () {
     });
 
 
-     function afterHeaderTestModel (name) {
+    function afterHeaderTestModel (name) {
         return {
             method: 'post',
             url: host + '/' + name,

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -493,12 +493,12 @@ describe('#addMethodREST', function () {
       });
     });
 
-    it('should run `afterHeader` on the params synchronously', function (done) {
+    it('should run `afterHeaders` on the params synchronously', function (done) {
       var name = randString(10);
       threadneedle.addMethod(name, {
         method: 'post',
         url: host + '/' + name,
-        afterHeader: function (error, headers, params, body, res) {
+        afterHeaders: function (error, headers, params, body, res) {
           headers.metaData = 'ABC';
         },
         data: {
@@ -513,17 +513,17 @@ describe('#addMethodREST', function () {
       threadneedle[name]({
         firstName: 'Chris'
       }).done(function(result) {
-        assert.deepEqual(result.header, { metaData: 'ABC' });
+        assert.deepEqual(result.headers, { metaData: 'ABC' });
         done();
       });
     });
 
-    it('should run `afterHeader` on the params asynchronously', function (done) {
+    it('should run `afterHeaders` on the params asynchronously', function (done) {
       var name = randString(10);
       threadneedle.addMethod(name, {
         method: 'post',
         url: host + '/' + name,
-        afterHeader: function (error, headers, params, body, res) {
+        afterHeaders: function (error, headers, params, body, res) {
           return when.promise(function (resolve) {
             headers.metaData = 'XYZ';
             resolve();
@@ -541,17 +541,17 @@ describe('#addMethodREST', function () {
       threadneedle[name]({
         firstName: 'Chris'
       }).done(function(result) {
-        assert.deepEqual(result.header, { metaData: 'XYZ' });
+        assert.deepEqual(result.headers, { metaData: 'XYZ' });
         done();
       });
     });
 
-    it('Should override with returned value in `afterHeader`', function (done) {
+    it('Should override with returned value in `afterHeaders`', function (done) {
       var name = randString(10);
       threadneedle.addMethod(name, {
         method: 'post',
         url: host + '/' + name,
-        afterHeader: function (error, headers, params, body, res) {
+        afterHeaders: function (error, headers, params, body, res) {
           headers.metaData = '123';
           return headers;
         },
@@ -567,7 +567,7 @@ describe('#addMethodREST', function () {
       threadneedle[name]({
         firstName: 'Chris'
       }).done(function(result) {
-        assert.deepEqual(result.header, { metaData: '123' });
+        assert.deepEqual(result.headers, { metaData: '123' });
         done();
       });
     });

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -607,8 +607,10 @@ describe('#addMethodREST', function () {
       threadneedle.addMethod(name, {
         method: 'post',
         url: host + '/' + name,
-        afterHeaders: function (error, headers, params, body, res) {
-          headers.metaData = 'ABC';
+        afterHeaders: function (error, params, body, res) {
+          return {
+              metaData: 'ABC'
+          };
         },
         data: {
           firstName: '{{firstName}}'
@@ -632,10 +634,11 @@ describe('#addMethodREST', function () {
       threadneedle.addMethod(name, {
         method: 'post',
         url: host + '/' + name,
-        afterHeaders: function (error, headers, params, body, res) {
+        afterHeaders: function (error, params, body, res) {
           return when.promise(function (resolve) {
-            headers.metaData = 'XYZ';
-            resolve();
+            resolve({
+                metaData: 'XYZ'
+            });
           });
         },
         data: {
@@ -655,33 +658,6 @@ describe('#addMethodREST', function () {
       });
     });
 
-    it('Should override with returned value in `afterHeaders`', function (done) {
-      var name = randString(10);
-      threadneedle.addMethod(name, {
-        method: 'post',
-        url: host + '/' + name,
-        afterHeaders: function (error, headers, params, body, res) {
-          headers.metaData = '123';
-          return headers;
-        },
-        data: {
-          firstName: '{{firstName}}'
-        }
-      });
-
-      app.post('/'+name, function (req, res) {
-        res.status(200).json([ req.body ]);
-      });
-
-      threadneedle[name]({
-        firstName: 'Chris'
-      }).done(function(result) {
-        assert.deepEqual(result.headers, { metaData: '123' });
-        done();
-      });
-    });
-
-
     function afterHeaderTestModel (name) {
         return {
             method: 'post',
@@ -697,13 +673,13 @@ describe('#addMethodREST', function () {
                     throw new Error('afterFailure Error');
                 }
             },
-            afterHeaders: function (error, headers, params, body, res) {
+            afterHeaders: function (error, params, body, res) {
                 if (params.ahFlag) {
                     throw new Error('afterHeaders Error');
                 } else {
                     return {
                         gotError: !!error
-                    }
+                    };
                 }
             }
         };

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -412,6 +412,7 @@ describe('#addMethodREST', function () {
       });
     });
 
+
     it('should run `afterSuccess` on the params synchronously', function (done) {
       var name = randString(10);
       threadneedle.addMethod(name, {
@@ -493,84 +494,6 @@ describe('#addMethodREST', function () {
       });
     });
 
-    it('should run `afterHeaders` on the params synchronously', function (done) {
-      var name = randString(10);
-      threadneedle.addMethod(name, {
-        method: 'post',
-        url: host + '/' + name,
-        afterHeaders: function (error, headers, params, body, res) {
-          headers.metaData = 'ABC';
-        },
-        data: {
-          firstName: '{{firstName}}'
-        }
-      });
-
-      app.post('/'+name, function (req, res) {
-        res.status(200).json(req.body);
-      });
-
-      threadneedle[name]({
-        firstName: 'Chris'
-      }).done(function(result) {
-        assert.deepEqual(result.headers, { metaData: 'ABC' });
-        done();
-      });
-    });
-
-    it('should run `afterHeaders` on the params asynchronously', function (done) {
-      var name = randString(10);
-      threadneedle.addMethod(name, {
-        method: 'post',
-        url: host + '/' + name,
-        afterHeaders: function (error, headers, params, body, res) {
-          return when.promise(function (resolve) {
-            headers.metaData = 'XYZ';
-            resolve();
-          });
-        },
-        data: {
-          firstName: '{{firstName}}'
-        }
-      });
-
-      app.post('/'+name, function (req, res) {
-        res.status(200).json(req.body);
-      });
-
-      threadneedle[name]({
-        firstName: 'Chris'
-      }).done(function(result) {
-        assert.deepEqual(result.headers, { metaData: 'XYZ' });
-        done();
-      });
-    });
-
-    it('Should override with returned value in `afterHeaders`', function (done) {
-      var name = randString(10);
-      threadneedle.addMethod(name, {
-        method: 'post',
-        url: host + '/' + name,
-        afterHeaders: function (error, headers, params, body, res) {
-          headers.metaData = '123';
-          return headers;
-        },
-        data: {
-          firstName: '{{firstName}}'
-        }
-      });
-
-      app.post('/'+name, function (req, res) {
-        res.status(200).json([ req.body ]);
-      });
-
-      threadneedle[name]({
-        firstName: 'Chris'
-      }).done(function(result) {
-        assert.deepEqual(result.headers, { metaData: '123' });
-        done();
-      });
-    });
 
     it('should run `afterFailure` on the params synchronously', function (done) {
       var name = randString(10);
@@ -677,6 +600,142 @@ describe('#addMethodREST', function () {
         done();
       });
     });
+
+
+    it('should run `afterHeaders` on the params synchronously', function (done) {
+      var name = randString(10);
+      threadneedle.addMethod(name, {
+        method: 'post',
+        url: host + '/' + name,
+        afterHeaders: function (error, headers, params, body, res) {
+          headers.metaData = 'ABC';
+        },
+        data: {
+          firstName: '{{firstName}}'
+        }
+      });
+
+      app.post('/'+name, function (req, res) {
+        res.status(200).json(req.body);
+      });
+
+      threadneedle[name]({
+        firstName: 'Chris'
+      }).done(function(result) {
+        assert.deepEqual(result.headers, { metaData: 'ABC' });
+        done();
+      });
+    });
+
+    it('should run `afterHeaders` on the params asynchronously', function (done) {
+      var name = randString(10);
+      threadneedle.addMethod(name, {
+        method: 'post',
+        url: host + '/' + name,
+        afterHeaders: function (error, headers, params, body, res) {
+          return when.promise(function (resolve) {
+            headers.metaData = 'XYZ';
+            resolve();
+          });
+        },
+        data: {
+          firstName: '{{firstName}}'
+        }
+      });
+
+      app.post('/'+name, function (req, res) {
+        res.status(200).json(req.body);
+      });
+
+      threadneedle[name]({
+        firstName: 'Chris'
+      }).done(function(result) {
+        assert.deepEqual(result.headers, { metaData: 'XYZ' });
+        done();
+      });
+    });
+
+    it('Should override with returned value in `afterHeaders`', function (done) {
+      var name = randString(10);
+      threadneedle.addMethod(name, {
+        method: 'post',
+        url: host + '/' + name,
+        afterHeaders: function (error, headers, params, body, res) {
+          headers.metaData = '123';
+          return headers;
+        },
+        data: {
+          firstName: '{{firstName}}'
+        }
+      });
+
+      app.post('/'+name, function (req, res) {
+        res.status(200).json([ req.body ]);
+      });
+
+      threadneedle[name]({
+        firstName: 'Chris'
+      }).done(function(result) {
+        assert.deepEqual(result.headers, { metaData: '123' });
+        done();
+      });
+    });
+
+    //TODO: 6 versions of test for all possibilities
+    // afterHeaderTestModel = {
+    //     method: 'post',
+    //     url: host + '/' + name,
+    //     afterSuccess: function (body, params, res) {
+    //         if (params.asFlag) {
+    //             throw new Error('afterSuccess Error');
+    //         }
+    //     },
+    //     afterFailure: function (body, params, res) {
+    //
+    //     },
+    //     afterHeaders: function (error, headers, params, body, res) {
+    //         if (params.ahFlag) {
+    //             throw new Error('afterHeaders Error');
+    //         } else {
+    //             return {
+    //                 gotError: !!error
+    //             }
+    //         }
+    //     }
+    // };
+
+
+    it('Should place `afterHeaders` errors in body and reject', function (done) {
+      var name = randString(10);
+      threadneedle.addMethod(name, {
+        method: 'post',
+        url: host + '/' + name,
+        afterHeaders: function (error, headers, params, body, res) {
+          throw new Error('Test Error');
+        },
+        data: {
+          firstName: '{{firstName}}'
+        }
+      });
+
+      app.post('/'+name, function (req, res) {
+        res.status(200).json([ req.body ]);
+      });
+
+      threadneedle[name]({
+        firstName: 'Chris'
+      }).done(
+          function () {
+            assert.fail('Wrong clause');
+            done();
+          },
+          function(result) {
+            assert.deepEqual(result.body.message, 'Test Error');
+            done();
+          }
+      );
+    });
+
 
     it('should add a {{temp_file}} parameter when `fileHandler` is true', function (done) {
       var name = randString(10);

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -498,7 +498,7 @@ describe('#addMethodREST', function () {
       threadneedle.addMethod(name, {
         method: 'post',
         url: host + '/' + name,
-        afterHeader: function (headers, params, body, res) {
+        afterHeader: function (error, headers, params, body, res) {
           headers.metaData = 'ABC';
         },
         data: {
@@ -523,7 +523,7 @@ describe('#addMethodREST', function () {
       threadneedle.addMethod(name, {
         method: 'post',
         url: host + '/' + name,
-        afterHeader: function (headers, params, body, res) {
+        afterHeader: function (error, headers, params, body, res) {
           return when.promise(function (resolve) {
             headers.metaData = 'XYZ';
             resolve();
@@ -551,7 +551,7 @@ describe('#addMethodREST', function () {
       threadneedle.addMethod(name, {
         method: 'post',
         url: host + '/' + name,
-        afterHeader: function (headers, params, body, res) {
+        afterHeader: function (error, headers, params, body, res) {
           headers.metaData = '123';
           return headers;
         },

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -233,8 +233,8 @@ describe('#addMethodREST', function () {
         res.status(200).json(req.headers);
       });
 
-      threadneedle[name]().done(function (result) {}, function (err) {
-        assert.equal(err.message, 'Invalid response status code');
+      threadneedle[name]().done(function (result) {}, function (result) {
+        assert.equal(result.body.message, 'Invalid response status code');
         done();
       });
     });
@@ -251,8 +251,8 @@ describe('#addMethodREST', function () {
         res.status(200).json(req.headers);
       });
 
-      threadneedle[name]().done(function (result) {}, function (err) {
-        assert.equal(err.message, 'Invalid response status code');
+      threadneedle[name]().done(function (result) {}, function (result) {
+        assert.equal(result.body.message, 'Invalid response status code');
         done();
       });
     });
@@ -269,8 +269,8 @@ describe('#addMethodREST', function () {
         res.status(200).json({ failure: true });
       });
 
-      threadneedle[name]().done(function (result) {}, function (err) {
-        assert.equal(err.message, 'Invalid response body');
+      threadneedle[name]().done(function (result) {}, function (result) {
+        assert.equal(result.body.message, 'Invalid response body');
         done();
       });
     });
@@ -305,8 +305,8 @@ describe('#addMethodREST', function () {
         res.status(200).json({ result: true });
       });
 
-      threadneedle[name]().done(function() {}, function (err) {
-        assert.equal(err.message, 'Invalid response status code');
+      threadneedle[name]().done(function() {}, function (result) {
+        assert.equal(result.body.message, 'Invalid response status code');
         done();
       });
     });
@@ -341,8 +341,8 @@ describe('#addMethodREST', function () {
         res.status(200).json({ result: true });
       });
 
-      threadneedle[name]().done(function() {}, function (err) {
-        assert.equal(err.message, 'Invalid response body');
+      threadneedle[name]().done(function() {}, function (result) {
+        assert.equal(result.body.message, 'Invalid response body');
         done();
       });
     });
@@ -593,8 +593,8 @@ describe('#addMethodREST', function () {
 
       threadneedle[name]({
         firstName: 'Chris'
-      }).done(function() {}, function (err) {
-        assert.deepEqual(err, {
+      }).done(function() {}, function (result) {
+        assert.deepEqual(result.body, {
           message: 'Invalid response status code',
           response: {
             statusCode: 200,
@@ -632,8 +632,8 @@ describe('#addMethodREST', function () {
 
       threadneedle[name]({
         firstName: 'Chris'
-      }).done(function() {}, function (err) {
-        assert.deepEqual(err, {
+      }).done(function() {}, function (result) {
+        assert.deepEqual(result.body, {
           message: 'Invalid response status code',
           response: {
             statusCode: 200,
@@ -672,8 +672,8 @@ describe('#addMethodREST', function () {
 
       threadneedle[name]({
         firstName: 'Chris'
-      }).done(function() {}, function (err) {
-        assert.equal(err.meh, 'no error here');
+      }).done(function() {}, function (result) {
+        assert.equal(result.body.meh, 'no error here');
         done();
       });
     });

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -10,7 +10,7 @@ var globalize    = require('../lib/addMethod/globalize');
 var ThreadNeedle = require('../');
 
 
-describe.only('#addMethodSOAP', function () {
+describe('#addMethodSOAP', function () {
 
     var regonline_token = require('./dummycredentials.json').regonline;
 
@@ -143,6 +143,7 @@ describe.only('#addMethodSOAP', function () {
             )
 
             .then(function (results) {
+                assert.deepEqual(results.headers, {});
                 assert(results.body['GetEventsResult']['Success']);
             })
 
@@ -239,6 +240,7 @@ describe.only('#addMethodSOAP', function () {
                     )
 
                     .then(function (results) {
+                        assert.deepEqual(results.headers, {});
                         assert(results.body['GetEventsResult']['Success']);
                     })
 
@@ -283,6 +285,7 @@ describe.only('#addMethodSOAP', function () {
                     .done(
                         promiseFailFunc(done),
                         function (err) {
+                            assert.deepEqual(err.headers, {});
                             assert(err.body.message === 'Test Error');
                             done();
                         }
@@ -406,6 +409,12 @@ describe.only('#addMethodSOAP', function () {
 
                     data: {
                         orderBy: 'ID DESC',
+                    },
+
+                    afterHeaders: function () {
+                        return {
+                            success: true
+                        }
                     }
 
                 }
@@ -415,6 +424,7 @@ describe.only('#addMethodSOAP', function () {
 
             .done(
                 function (val) {
+                    assert.deepEqual(val.headers.success, true);
                     assert(val.body['GetEventsResult']['Success']);
                     done();
                 },

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -360,7 +360,7 @@ describe('#addMethodSOAP', function () {
 
             .done(
                 function (val) {
-                    assert(val === 'Chris');
+                    assert.deepEqual(val.body, 'Chris');
                     done();
                 },
                 function (err) {

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -10,7 +10,7 @@ var globalize    = require('../lib/addMethod/globalize');
 var ThreadNeedle = require('../');
 
 
-describe('#addMethodSOAP', function () {
+describe.only('#addMethodSOAP', function () {
 
     var regonline_token = require('./dummycredentials.json').regonline;
 
@@ -143,7 +143,7 @@ describe('#addMethodSOAP', function () {
             )
 
             .then(function (results) {
-                assert(results['GetEventsResult']['Success']);
+                assert(results.body['GetEventsResult']['Success']);
             })
 
             .done(done, promiseFailFunc(done));
@@ -178,7 +178,7 @@ describe('#addMethodSOAP', function () {
                     )
 
                     .then(function (results) {
-                        assert(results['GetEventsResult']['Success']);
+                        assert(results.body['GetEventsResult']['Success']);
                     })
 
                     .done(done, promiseFailFunc(done));
@@ -239,7 +239,7 @@ describe('#addMethodSOAP', function () {
                     )
 
                     .then(function (results) {
-                        assert(results['GetEventsResult']['Success']);
+                        assert(results.body['GetEventsResult']['Success']);
                     })
 
                     .done(done, promiseFailFunc(done));
@@ -283,7 +283,7 @@ describe('#addMethodSOAP', function () {
                     .done(
                         promiseFailFunc(done),
                         function (err) {
-                            assert(err.message === 'Test Error');
+                            assert(err.body.message === 'Test Error');
                             done();
                         }
                     );
@@ -326,7 +326,7 @@ describe('#addMethodSOAP', function () {
                     .done(
                         promiseFailFunc(done),
                         function (err) {
-                            assert(err.message === 'Test Error');
+                            assert(err.body.message === 'Test Error');
                             done();
                         }
                     );
@@ -415,7 +415,7 @@ describe('#addMethodSOAP', function () {
 
             .done(
                 function (val) {
-                    assert(val['GetEventsResult']['Success']);
+                    assert(val.body['GetEventsResult']['Success']);
                     done();
                 },
                 function (err) {

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -6,807 +6,928 @@ var globalize    = require('../lib/addMethod/globalize');
 
 describe('#globalize', function () {
 
-  describe('#url', function () {
+    describe('#url', function () {
 
-    it('should add the global url on the front unless it starts with http(s)://', function () {
-      var sample = {
-        _globalOptions: {
-          url: 'http://mydomain.com'
-        }
-      };
-
-      assert.strictEqual(
-        globalize.baseUrl.call(sample, { url: '/mypath' }, {}),
-        'http://mydomain.com/mypath'
-      );
-
-      assert.strictEqual(
-        globalize.baseUrl.call(sample, { url: 'http://yourdomain.com/mypath' }, {}),
-        'http://yourdomain.com/mypath'
-      );
-
-      assert.strictEqual(
-        globalize.baseUrl.call(sample, { url: 'https://yourdomain.com/mypath' }, {}),
-        'https://yourdomain.com/mypath'
-      );
-    });
-
-    it('should substitute parameters to string urls', function () {
-      var sample = {
-        _globalOptions: {
-          url: 'http://{{dc}}.mydomain.com'
-        }
-      };
-
-      assert.strictEqual(
-        globalize.baseUrl.call(sample, { url: '/mypath/{{id}}' }, {
-          dc: 'us5',
-          id: '123'
-        }),
-        'http://us5.mydomain.com/mypath/123'
-      );
-    });
-
-    it('should substitute array parameters as comma separated', function () {
-      var sample = {
-        _globalOptions: {
-          url: 'http://{{dc}}.mydomain.com'
-        }
-      };
-
-      assert.strictEqual(
-        globalize.baseUrl.call(sample, { url: '/mypath/{{id}}?opt_fields={{fields}}' }, {
-          dc: 'us5',
-          id: '123',
-          fields: ['id', 'name', 'is_organization']
-        }),
-        'http://us5.mydomain.com/mypath/123?opt_fields=id,name,is_organization'
-      );
-    });
-
-    it('should substitute parameters to function urls', function () {
-      var sample = {
-        _globalOptions: {
-          url: function (params) {
-            return 'http://'+params.dc+'.mydomain.com';
-          }
-        }
-      };
-
-      assert.strictEqual(
-        globalize.baseUrl.call(sample, {
-          url: function(params) {
-            return '/mypath/' + params.id;
-          }
-        }, {
-          dc: 'us5',
-          id: '123'
-        }),
-        'http://us5.mydomain.com/mypath/123'
-      );
-    });
-
-    it('should not run the global when globals is false', function () {
-      var sample = {
-        _globalOptions: {
-          url: 'http://mydomain.com'
-        }
-      };
-
-      assert.strictEqual(
-        globalize.baseUrl.call(sample, { url: '/mypath', globals: false }, {}),
-        '/mypath'
-      );
-
-      assert.strictEqual(
-        globalize.baseUrl.call(sample, { url: '/mypath', globals: { baseUrl: false } }, {}),
-        '/mypath'
-      );
-    });
-
-  });
-
-  describe('#object', function () {
-
-    it('should globalize to an object on a shallow level', function () {
-      var sample = {
-        _globalOptions: {
-          data: {
-            id: '123',
-            name: 'Chris'
-          }
-        }
-      };
-
-      assert.deepEqual(
-        globalize.object.call(sample, 'data', {
-          data: {
-            age: 25,
-            height: 180
-          }
-        }, {}), {
-          id: '123',
-          name: 'Chris',
-          age: 25,
-          height: 180
-        }
-      );
-    });
-
-    it('should globalize to an object on a deep level', function () {
-      var sample = {
-        _globalOptions: {
-          data: {
-            id: '123',
-            name: 'Chris',
-            height: {
-              m: 1.9
+        it('should add the global url on the front unless it starts with http(s)://', function () {
+          var sample = {
+            _globalOptions: {
+              url: 'http://mydomain.com'
             }
-          }
-        }
-      };
+          };
 
-      assert.deepEqual(
-        globalize.object.call(sample, 'data', {
-          data: {
-            age: 25,
-            height: {
-              cm: 180,
-              m: 1.8
+          assert.strictEqual(
+            globalize.baseUrl.call(sample, { url: '/mypath' }, {}),
+            'http://mydomain.com/mypath'
+          );
+
+          assert.strictEqual(
+            globalize.baseUrl.call(sample, { url: 'http://yourdomain.com/mypath' }, {}),
+            'http://yourdomain.com/mypath'
+          );
+
+          assert.strictEqual(
+            globalize.baseUrl.call(sample, { url: 'https://yourdomain.com/mypath' }, {}),
+            'https://yourdomain.com/mypath'
+          );
+        });
+
+        it('should substitute parameters to string urls', function () {
+          var sample = {
+            _globalOptions: {
+              url: 'http://{{dc}}.mydomain.com'
             }
-          }
-        }, {}), {
-          id: '123',
-          name: 'Chris',
-          age: 25,
-          height: {
-            cm: 180,
-            m: 1.8
-          }
-        }
-      );
+          };
+
+          assert.strictEqual(
+            globalize.baseUrl.call(sample, { url: '/mypath/{{id}}' }, {
+              dc: 'us5',
+              id: '123'
+            }),
+            'http://us5.mydomain.com/mypath/123'
+          );
+        });
+
+        it('should substitute array parameters as comma separated', function () {
+          var sample = {
+            _globalOptions: {
+              url: 'http://{{dc}}.mydomain.com'
+            }
+          };
+
+          assert.strictEqual(
+            globalize.baseUrl.call(sample, { url: '/mypath/{{id}}?opt_fields={{fields}}' }, {
+              dc: 'us5',
+              id: '123',
+              fields: ['id', 'name', 'is_organization']
+            }),
+            'http://us5.mydomain.com/mypath/123?opt_fields=id,name,is_organization'
+          );
+        });
+
+        it('should substitute parameters to function urls', function () {
+          var sample = {
+            _globalOptions: {
+              url: function (params) {
+                return 'http://'+params.dc+'.mydomain.com';
+              }
+            }
+          };
+
+          assert.strictEqual(
+            globalize.baseUrl.call(sample, {
+              url: function(params) {
+                return '/mypath/' + params.id;
+              }
+            }, {
+              dc: 'us5',
+              id: '123'
+            }),
+            'http://us5.mydomain.com/mypath/123'
+          );
+        });
+
+        it('should not run the global when globals is false', function () {
+          var sample = {
+            _globalOptions: {
+              url: 'http://mydomain.com'
+            }
+          };
+
+          assert.strictEqual(
+            globalize.baseUrl.call(sample, { url: '/mypath', globals: false }, {}),
+            '/mypath'
+          );
+
+          assert.strictEqual(
+            globalize.baseUrl.call(sample, { url: '/mypath', globals: { baseUrl: false } }, {}),
+            '/mypath'
+          );
+        });
+
     });
 
-    it('should substitute to an global object on a deep level', function () {
-      var sample = {
-        _globalOptions: {
-          data: {
-            id: '123',
-            firstName: '{{firstName}}',
-            lastName: '{{lastName}}'
-          }
-        }
-      };
+    describe('#object', function () {
 
-      assert.deepEqual(
-        globalize.object.call(sample, 'data', {
-          data: {
-            name: '{{name}}'
-          }
-        }, {
-          name: 'Chris Houghton',
-          firstName: 'Chris',
-          lastName: 'Houghton'
-        }), {
-          id: '123',
-          name: 'Chris Houghton',
-          firstName: 'Chris',
-          lastName: 'Houghton'
-        }
-      );
+        it('should globalize to an object on a shallow level', function () {
+          var sample = {
+            _globalOptions: {
+              data: {
+                id: '123',
+                name: 'Chris'
+              }
+            }
+          };
+
+          assert.deepEqual(
+            globalize.object.call(sample, 'data', {
+              data: {
+                age: 25,
+                height: 180
+              }
+            }, {}), {
+              id: '123',
+              name: 'Chris',
+              age: 25,
+              height: 180
+            }
+          );
+        });
+
+        it('should globalize to an object on a deep level', function () {
+          var sample = {
+            _globalOptions: {
+              data: {
+                id: '123',
+                name: 'Chris',
+                height: {
+                  m: 1.9
+                }
+              }
+            }
+          };
+
+          assert.deepEqual(
+            globalize.object.call(sample, 'data', {
+              data: {
+                age: 25,
+                height: {
+                  cm: 180,
+                  m: 1.8
+                }
+              }
+            }, {}), {
+              id: '123',
+              name: 'Chris',
+              age: 25,
+              height: {
+                cm: 180,
+                m: 1.8
+              }
+            }
+          );
+        });
+
+        it('should substitute to an global object on a deep level', function () {
+          var sample = {
+            _globalOptions: {
+              data: {
+                id: '123',
+                firstName: '{{firstName}}',
+                lastName: '{{lastName}}'
+              }
+            }
+          };
+
+          assert.deepEqual(
+            globalize.object.call(sample, 'data', {
+              data: {
+                name: '{{name}}'
+              }
+            }, {
+              name: 'Chris Houghton',
+              firstName: 'Chris',
+              lastName: 'Houghton'
+            }), {
+              id: '123',
+              name: 'Chris Houghton',
+              firstName: 'Chris',
+              lastName: 'Houghton'
+            }
+          );
+        });
+
+        it('should return local string if data is a string', function () {
+          var sample = {
+            _globalOptions: {
+              data: {
+                id: '123',
+                name: 'Chris'
+              }
+            }
+          };
+
+          assert.deepEqual(
+            globalize.object.call(sample, 'data', {
+              globals: false,
+              data: "Lorem ipsum"
+            }, {}),
+            "Lorem ipsum"
+          );
+
+
+        });
+
+        it('should not globalize when globals is false', function () {
+          var sample = {
+            _globalOptions: {
+              data: {
+                id: '123',
+                name: 'Chris'
+              }
+            }
+          };
+
+          assert.deepEqual(
+            globalize.object.call(sample, 'data', {
+              globals: false,
+              data: {
+                age: 25,
+                height: 180
+              }
+            }, {}), {
+              age: 25,
+              height: 180
+            }
+          );
+
+          assert.deepEqual(
+            globalize.object.call(sample, 'data', {
+              globals: {
+                  data: false
+              },
+              data: {
+                age: 25,
+                height: 180
+              }
+            }, {}), {
+              age: 25,
+              height: 180
+            }
+          );
+        });
+
+
     });
 
-    it('should return local string if data is a string', function () {
-      var sample = {
-        _globalOptions: {
-          data: {
-            id: '123',
-            name: 'Chris'
-          }
-        }
-      };
 
-      assert.deepEqual(
-        globalize.object.call(sample, 'data', {
-          globals: false,
-          data: "Lorem ipsum"
-        }, {}),
-        "Lorem ipsum"
-      );
+    describe('#before', function () {
+
+        it('should run the global before method when declared', function (done) {
+          var sample = {
+            _globalOptions: {
+              before: function (params) {
+                params.dc = 'us5';
+              }
+            }
+          };
+
+          globalize.before.call(sample, {}, {
+            url: '/mydomain'
+          }).done(function (params) {
+            assert.deepEqual(params, { url: '/mydomain', dc: 'us5' });
+            done();
+          });
+        });
+
+        it('should allow for a global promise async', function (done) {
+          var sample = {
+            _globalOptions: {
+              before: function (params) {
+                return when.promise(function (resolve, reject) {
+                  params.dc = 'us5';
+                  resolve();
+                });
+              }
+            }
+          };
+
+          globalize.before.call(sample, {}, {
+            url: '/mydomain'
+          }).done(function (params) {
+            assert.deepEqual(params, { url: '/mydomain', dc: 'us5' });
+            done();
+          });
+        });
+
+        it('should call the global promise before the local one', function (done) {
+          var calledFirst;
+          var calls = 0;
+
+          var sample = {
+            _globalOptions: {
+              before: function (params) {
+                if (!calledFirst) calledFirst = 'global';
+                calls++;
+              }
+            }
+          };
+
+          globalize.before.call(sample, {
+            before: function() {
+              if (!calledFirst) calledFirst = 'local';
+              calls++
+            }
+          }, {}).done(function(params) {
+            assert.equal(calledFirst, 'global');
+            assert.equal(calls, 2);
+            done();
+          });
+        });
+
+        it('should not run global before when globals is false', function (done) {
+          var sample = {
+            _globalOptions: {
+              before: function (params) {
+                params.dc = 'us5';
+              }
+            }
+          };
+
+          globalize.before.call(sample, {
+            globals: false,
+            url: '/mydomain/{{id}}'
+          }, {
+            id: '123'
+          }).done(function (params) {
+            assert.deepEqual(params, { id: '123' });
+          });
+
+          globalize.before.call(sample, {
+            globals: {
+                before: false
+            },
+            url: '/mydomain/{{id}}'
+          }, {
+            id: '123'
+          }).done(function (params) {
+            assert.deepEqual(params, { id: '123' });
+            done();
+          });
+        });
+
+        it('should use baseUrl rather than url, but still fall back to url', function () {
+          assert.strictEqual(
+            globalize.baseUrl.call({
+              _globalOptions: {
+                baseUrl: 'http://mydomain.com'
+              }
+            }, { url: '/mypath' }, {}),
+            'http://mydomain.com/mypath'
+          );
+
+          assert.strictEqual(
+            globalize.baseUrl.call({
+              _globalOptions: {
+                url: 'http://mydomain.com'
+              }
+            }, { url: '/mypath' }, {}),
+            'http://mydomain.com/mypath'
+          );
+        });
+
+    });
+
+    describe.skip('#beforeRequest', function () {
 
 
     });
 
-    it('should not globalize when globals is false', function () {
-      var sample = {
-        _globalOptions: {
-          data: {
-            id: '123',
-            name: 'Chris'
-          }
-        }
-      };
 
-      assert.deepEqual(
-        globalize.object.call(sample, 'data', {
-          globals: false,
-          data: {
-            age: 25,
-            height: 180
-          }
-        }, {}), {
-          age: 25,
-          height: 180
-        }
-      );
+    describe('#expects', function () {
 
-      assert.deepEqual(
-        globalize.object.call(sample, 'data', {
-          globals: {
-              data: false
-          },
-          data: {
-            age: 25,
-            height: 180
-          }
-        }, {}), {
-          age: 25,
-          height: 180
-        }
-      );
-    });
+        it('should set the expects object when specified in global', function () {
+          var sample = {
+            _globalOptions: {
+              expects: 200
+            }
+          };
+          assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
 
-
-  });
-
-
-  describe('#before', function () {
-
-    it('should run the global before method when declared', function (done) {
-      var sample = {
-        _globalOptions: {
-          before: function (params) {
-            params.dc = 'us5';
-          }
-        }
-      };
-
-      globalize.before.call(sample, {}, {
-        url: '/mydomain'
-      }).done(function (params) {
-        assert.deepEqual(params, { url: '/mydomain', dc: 'us5' });
-        done();
-      });
-    });
-
-    it('should allow for a global promise async', function (done) {
-      var sample = {
-        _globalOptions: {
-          before: function (params) {
-            return when.promise(function (resolve, reject) {
-              params.dc = 'us5';
-              resolve();
-            });
-          }
-        }
-      };
-
-      globalize.before.call(sample, {}, {
-        url: '/mydomain'
-      }).done(function (params) {
-        assert.deepEqual(params, { url: '/mydomain', dc: 'us5' });
-        done();
-      });
-    });
-
-    it('should call the global promise before the local one', function (done) {
-      var calledFirst;
-      var calls = 0;
-
-      var sample = {
-        _globalOptions: {
-          before: function (params) {
-            if (!calledFirst) calledFirst = 'global';
-            calls++;
-          }
-        }
-      };
-
-      globalize.before.call(sample, {
-        before: function() {
-          if (!calledFirst) calledFirst = 'local';
-          calls++
-        }
-      }, {}).done(function(params) {
-        assert.equal(calledFirst, 'global');
-        assert.equal(calls, 2);
-        done();
-      });
-    });
-
-    it('should not run global before when globals is false', function (done) {
-      var sample = {
-        _globalOptions: {
-          before: function (params) {
-            params.dc = 'us5';
-          }
-        }
-      };
-
-      globalize.before.call(sample, {
-        globals: false,
-        url: '/mydomain/{{id}}'
-      }, {
-        id: '123'
-      }).done(function (params) {
-        assert.deepEqual(params, { id: '123' });
-      });
-
-      globalize.before.call(sample, {
-        globals: {
-            before: false
-        },
-        url: '/mydomain/{{id}}'
-      }, {
-        id: '123'
-      }).done(function (params) {
-        assert.deepEqual(params, { id: '123' });
-        done();
-      });
-    });
-
-    it('should use baseUrl rather than url, but still fall back to url', function () {
-      assert.strictEqual(
-        globalize.baseUrl.call({
-          _globalOptions: {
-            baseUrl: 'http://mydomain.com'
-          }
-        }, { url: '/mypath' }, {}),
-        'http://mydomain.com/mypath'
-      );
-
-      assert.strictEqual(
-        globalize.baseUrl.call({
-          _globalOptions: {
-            url: 'http://mydomain.com'
-          }
-        }, { url: '/mypath' }, {}),
-        'http://mydomain.com/mypath'
-      );
-    });
-
-  });
-
-  describe.skip('#beforeRequest', function () {
-
-
-  });
-
-
-  describe('#expects', function () {
-
-    it('should set the expects object when specified in global', function () {
-      var sample = {
-        _globalOptions: {
-          expects: 200
-        }
-      };
-      assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
-
-      var sample = {
-        _globalOptions: {
-          expects: {
+          var sample = {
+            _globalOptions: {
+              expects: {
+                statusCode: [200, 201],
+                body: 'chris'
+              }
+            }
+          };
+          assert.deepEqual(globalize.expects.call(sample, {}), [{
             statusCode: [200, 201],
-            body: 'chris'
-          }
-        }
-      };
-      assert.deepEqual(globalize.expects.call(sample, {}), [{
-        statusCode: [200, 201],
-        body: ['chris']
-      }]);
+            body: ['chris']
+          }]);
+        });
+
+        it('should be overridden by the local config', function () {
+          var sample = {
+            _globalOptions: {
+              expects: 200
+            }
+          };
+          assert.deepEqual(globalize.expects.call(sample, {
+            expects: {
+              statusCode: 201
+            }
+          }), [{
+            statusCode: [201]
+          }]);
+
+          assert.deepEqual(globalize.expects.call(sample, {
+            expects: 202
+          }), [{
+            statusCode: [202]
+          }]);
+        });
+
+        it('should not merge when there are functions on the global or local level', function () {
+          var sample = {
+            _globalOptions: {
+              expects: function () {
+                return 'Bad things';
+              }
+            }
+          };
+          assert.strictEqual(globalize.expects.call(sample, {
+            expects: {
+              body: 'steve'
+            }
+          }).length, 2);
+
+          var sample = {
+            _globalOptions: {
+              expects: function () {
+                return 'Bad things';
+              }
+            }
+          };
+          assert.strictEqual(globalize.expects.call(sample, {
+            expects: function () {
+              return 'Locally bad things';
+            }
+          }).length, 2);
+
+          var sample = {
+            _globalOptions: {
+              notExpects: [200]
+            }
+          };
+          assert.strictEqual(globalize.expects.call(sample, {
+            expects: function () {
+              return 'Locally bad things';
+            }
+          }).length, 2);
+        });
+
+        it('should not run global when globals is false', function () {
+          var sample = {
+            _globalOptions: {
+              expects: 200
+            }
+          };
+          assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
+
+          var sample = {
+            _globalOptions: {
+              expects: {
+                statusCode: [200, 201],
+                body: 'chris'
+              }
+            }
+          };
+          assert.deepEqual(globalize.expects.call(sample, {
+            globals: false
+          }), [{}]);
+        });
+
+        it('should not run global when globals.expects is false', function () {
+          var sample = {
+            _globalOptions: {
+              expects: 200
+            }
+          };
+          assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
+
+          var sample = {
+            _globalOptions: {
+              expects: {
+                statusCode: [200, 201],
+                body: 'chris'
+              }
+            }
+          };
+          assert.deepEqual(globalize.expects.call(sample, {
+            globals: {
+                expects: false
+            }
+          }), [{}]);
+        });
+
     });
 
-    it('should be overridden by the local config', function () {
-      var sample = {
-        _globalOptions: {
-          expects: 200
-        }
-      };
-      assert.deepEqual(globalize.expects.call(sample, {
-        expects: {
-          statusCode: 201
-        }
-      }), [{
-        statusCode: [201]
-      }]);
+    describe('#notExpects', function () {
 
-      assert.deepEqual(globalize.expects.call(sample, {
-        expects: 202
-      }), [{
-        statusCode: [202]
-      }]);
-    });
+        it('should set the expects object when specified in global', function () {
+          var sample = {
+            _globalOptions: {
+              notExpects: 200
+            }
+          };
+          assert.deepEqual(globalize.notExpects.call(sample, {}), [{ statusCode: [200] }]);
 
-    it('should not merge when there are functions on the global or local level', function () {
-      var sample = {
-        _globalOptions: {
-          expects: function () {
-            return 'Bad things';
-          }
-        }
-      };
-      assert.strictEqual(globalize.expects.call(sample, {
-        expects: {
-          body: 'steve'
-        }
-      }).length, 2);
-
-      var sample = {
-        _globalOptions: {
-          expects: function () {
-            return 'Bad things';
-          }
-        }
-      };
-      assert.strictEqual(globalize.expects.call(sample, {
-        expects: function () {
-          return 'Locally bad things';
-        }
-      }).length, 2);
-
-      var sample = {
-        _globalOptions: {
-          notExpects: [200]
-        }
-      };
-      assert.strictEqual(globalize.expects.call(sample, {
-        expects: function () {
-          return 'Locally bad things';
-        }
-      }).length, 2);
-    });
-
-    it('should not run global when globals is false', function () {
-      var sample = {
-        _globalOptions: {
-          expects: 200
-        }
-      };
-      assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
-
-      var sample = {
-        _globalOptions: {
-          expects: {
+          var sample = {
+            _globalOptions: {
+              notExpects: {
+                statusCode: [200, 201],
+                body: 'chris'
+              }
+            }
+          };
+          assert.deepEqual(globalize.notExpects.call(sample, {}), [{
             statusCode: [200, 201],
-            body: 'chris'
-          }
-        }
-      };
-      assert.deepEqual(globalize.expects.call(sample, {
-        globals: false
-      }), [{}]);
-    });
+            body: ['chris']
+          }]);
+        });
 
-    it('should not run global when globals.expects is false', function () {
-      var sample = {
-        _globalOptions: {
-          expects: 200
-        }
-      };
-      assert.deepEqual(globalize.expects.call(sample, {}), [{ statusCode: [200] }]);
+        it('should be overridden by the local config', function () {
+          var sample = {
+            _globalOptions: {
+              notExpects: 200
+            }
+          };
+          assert.deepEqual(globalize.notExpects.call(sample, {
+            notExpects: {
+              statusCode: 201
+            }
+          }), [{
+            statusCode: [201]
+          }]);
 
-      var sample = {
-        _globalOptions: {
-          expects: {
-            statusCode: [200, 201],
-            body: 'chris'
-          }
-        }
-      };
-      assert.deepEqual(globalize.expects.call(sample, {
-        globals: {
-            expects: false
-        }
-      }), [{}]);
-    });
-
-  });
-
-  describe('#notExpects', function () {
-
-    it('should set the expects object when specified in global', function () {
-      var sample = {
-        _globalOptions: {
-          notExpects: 200
-        }
-      };
-      assert.deepEqual(globalize.notExpects.call(sample, {}), [{ statusCode: [200] }]);
-
-      var sample = {
-        _globalOptions: {
-          notExpects: {
-            statusCode: [200, 201],
-            body: 'chris'
-          }
-        }
-      };
-      assert.deepEqual(globalize.notExpects.call(sample, {}), [{
-        statusCode: [200, 201],
-        body: ['chris']
-      }]);
-    });
-
-    it('should be overridden by the local config', function () {
-      var sample = {
-        _globalOptions: {
-          notExpects: 200
-        }
-      };
-      assert.deepEqual(globalize.notExpects.call(sample, {
-        notExpects: {
-          statusCode: 201
-        }
-      }), [{
-        statusCode: [201]
-      }]);
-
-      assert.deepEqual(globalize.notExpects.call(sample, {
-        notExpects: 202
-      }), [{
-        statusCode: [202]
-      }]);
-    });
+          assert.deepEqual(globalize.notExpects.call(sample, {
+            notExpects: 202
+          }), [{
+            statusCode: [202]
+          }]);
+        });
 
 
-    it('should not set the notExpects object when false is specified in globals', function () {
-      var sample = {
-        _globalOptions: {
-          notExpects: {
-            statusCode: [200, 201],
-            body: 'chris'
-          }
-        }
-      };
+        it('should not set the notExpects object when false is specified in globals', function () {
+          var sample = {
+            _globalOptions: {
+              notExpects: {
+                statusCode: [200, 201],
+                body: 'chris'
+              }
+            }
+          };
 
-      assert.deepEqual(globalize.notExpects.call(sample, {
-        notExpects: {
-          body: 'steve'
-        },
-        globals: false
-      }), [{
-        body: ['steve']
-      }]);
+          assert.deepEqual(globalize.notExpects.call(sample, {
+            notExpects: {
+              body: 'steve'
+            },
+            globals: false
+          }), [{
+            body: ['steve']
+          }]);
 
-      assert.deepEqual(globalize.notExpects.call(sample, {
-        notExpects: {
-          body: 'steve'
-        },
-        globals: {
-            notExpects: false
-        }
-      }), [{
-        body: ['steve']
-      }]);
-    });
+          assert.deepEqual(globalize.notExpects.call(sample, {
+            notExpects: {
+              body: 'steve'
+            },
+            globals: {
+                notExpects: false
+            }
+          }), [{
+            body: ['steve']
+          }]);
+        });
 
-    it('should not merge when there are functions on the global or local level', function () {
-      var sample = {
-        _globalOptions: {
-          notExpects: function () {
-            return 'Bad things';
-          }
-        }
-      };
-      assert.strictEqual(globalize.notExpects.call(sample, {
-        notExpects: {
-          body: 'steve'
-        }
-      }).length, 2);
+        it('should not merge when there are functions on the global or local level', function () {
+          var sample = {
+            _globalOptions: {
+              notExpects: function () {
+                return 'Bad things';
+              }
+            }
+          };
+          assert.strictEqual(globalize.notExpects.call(sample, {
+            notExpects: {
+              body: 'steve'
+            }
+          }).length, 2);
 
-      var sample = {
-        _globalOptions: {
-          notExpects: function () {
-            return 'Bad things';
-          }
-        }
-      };
-      assert.strictEqual(globalize.notExpects.call(sample, {
-        notExpects: function () {
-          return 'Locally bad things';
-        }
-      }).length, 2);
+          var sample = {
+            _globalOptions: {
+              notExpects: function () {
+                return 'Bad things';
+              }
+            }
+          };
+          assert.strictEqual(globalize.notExpects.call(sample, {
+            notExpects: function () {
+              return 'Locally bad things';
+            }
+          }).length, 2);
 
-      var sample = {
-        _globalOptions: {
-          notExpects: [200]
-        }
-      };
-      assert.strictEqual(globalize.notExpects.call(sample, {
-        notExpects: function () {
-          return 'Locally bad things';
-        }
-      }).length, 2);
-    });
+          var sample = {
+            _globalOptions: {
+              notExpects: [200]
+            }
+          };
+          assert.strictEqual(globalize.notExpects.call(sample, {
+            notExpects: function () {
+              return 'Locally bad things';
+            }
+          }).length, 2);
+        });
 
-  });
-
-
-  describe('#afterSuccess', function () {
-
-    it('should run the global before method when declared', function (done) {
-      var sample = {
-        _globalOptions: {
-          afterSuccess: function (body) {
-            body.success = true;
-          }
-        }
-      };
-
-      globalize.afterSuccess.call(sample, {}, {}).done(function (body) {
-        assert.deepEqual(body, { success: true });
-        done();
-      });
-    });
-
-    it('should allow for a global promise async', function (done) {
-      var sample = {
-        _globalOptions: {
-          afterSuccess: function (body) {
-            return when.promise(function (resolve, reject) {
-              body.success = true;
-              resolve();
-            });
-          }
-        }
-      };
-
-      globalize.afterSuccess.call(sample, {}, {}).done(function (body) {
-        assert.deepEqual(body, { success: true });
-        done();
-      });
-    });
-
-    it('should call the global promise before the local one', function (done) {
-      var calledFirst;
-      var calls = 0;
-
-      var sample = {
-        _globalOptions: {
-          afterSuccess: function (params) {
-            if (!calledFirst) calledFirst = 'global';
-            calls++;
-          }
-        }
-      };
-
-      globalize.afterSuccess.call(sample, {
-        afterSuccess: function() {
-          if (!calledFirst) calledFirst = 'local';
-          calls++
-        }
-      }, {}).done(function(params) {
-        assert.equal(calledFirst, 'global');
-        assert.equal(calls, 2);
-        done();
-      });
-    });
-
-    it('should not run the globals when globals is false', function (done) {
-      var sample = {
-        _globalOptions: {
-          afterSuccess: function (body) {
-            body.success = true;
-          }
-        }
-      };
-
-      globalize.afterSuccess.call(sample, {
-        globals: false
-      }, {}).done(function (body) {
-        assert.deepEqual(body, {});
-        //done();
-      });
-
-      globalize.afterSuccess.call(sample, {
-        globals: {
-            afterSuccess: false
-        }
-      }, {}).done(function (body) {
-        assert.deepEqual(body, {});
-        done();
-      });
-    });
-
-  });
-
-  describe('#afterFailure', function () {
-
-    it('should run the global before method when declared', function (done) {
-      var sample = {
-        _globalOptions: {
-          afterFailure: function (err) {
-            err.code = 'oauth_refresh';
-          }
-        }
-      };
-
-      globalize.afterFailure.call(sample, {}, {}).done(function (err) {
-        assert.deepEqual(err, { code: 'oauth_refresh' });
-        done();
-      });
-    });
-
-    it('should allow for a global promise async', function (done) {
-      var sample = {
-        _globalOptions: {
-          afterFailure: function (err) {
-            return when.promise(function (resolve, reject) {
-              err.code = 'oauth_refresh';
-              resolve();
-            });
-          }
-        }
-      };
-
-      globalize.afterFailure.call(sample, {}, {}).done(function (err) {
-        assert.deepEqual(err, { code: 'oauth_refresh' });
-        done();
-      });
-    });
-
-    it('should call the global promise before the local one', function (done) {
-      var calledFirst;
-      var calls = 0;
-
-      var sample = {
-        _globalOptions: {
-          afterFailure: function () {
-            if (!calledFirst) calledFirst = 'global';
-            calls++;
-          }
-        }
-      };
-
-      globalize.afterFailure.call(sample, {
-        afterFailure: function() {
-          if (!calledFirst) calledFirst = 'local';
-          calls++
-        }
-      }, {}).done(function() {
-        assert.equal(calledFirst, 'global');
-        assert.equal(calls, 2);
-        done();
-      });
-    });
-
-    it('should not run the global when globals is false', function (done) {
-      var sample = {
-        _globalOptions: {
-          afterFailure: function (err) {
-            err.code = 'oauth_refresh';
-          }
-        }
-      };
-
-      globalize.afterFailure.call(sample, {
-        globals: false
-      }, {}).done(function (err) {
-        assert.deepEqual(err, {});
-        //done();
-      });
-
-      globalize.afterFailure.call(sample, {
-        globals: {
-            afterFailure: false
-        }
-      }, {}).done(function (err) {
-        assert.deepEqual(err, {});
-        done();
-      });
     });
 
 
-  });
+    describe('#afterSuccess', function () {
+
+        it('should run the global before method when declared', function (done) {
+          var sample = {
+            _globalOptions: {
+              afterSuccess: function (body) {
+                body.success = true;
+              }
+            }
+          };
+
+          globalize.afterSuccess.call(sample, {}, {}).done(function (body) {
+            assert.deepEqual(body, { success: true });
+            done();
+          });
+        });
+
+        it('should allow for a global promise async', function (done) {
+          var sample = {
+            _globalOptions: {
+              afterSuccess: function (body) {
+                return when.promise(function (resolve, reject) {
+                  body.success = true;
+                  resolve();
+                });
+              }
+            }
+          };
+
+          globalize.afterSuccess.call(sample, {}, {}).done(function (body) {
+            assert.deepEqual(body, { success: true });
+            done();
+          });
+        });
+
+        it('should call the global promise before the local one', function (done) {
+          var calledFirst;
+          var calls = 0;
+
+          var sample = {
+            _globalOptions: {
+              afterSuccess: function (params) {
+                if (!calledFirst) calledFirst = 'global';
+                calls++;
+              }
+            }
+          };
+
+          globalize.afterSuccess.call(sample, {
+            afterSuccess: function() {
+              if (!calledFirst) calledFirst = 'local';
+              calls++
+            }
+          }, {}).done(function(params) {
+            assert.equal(calledFirst, 'global');
+            assert.equal(calls, 2);
+            done();
+          });
+        });
+
+        it('should not run the globals when globals is false', function (done) {
+          var sample = {
+            _globalOptions: {
+              afterSuccess: function (body) {
+                body.success = true;
+              }
+            }
+          };
+
+          globalize.afterSuccess.call(sample, {
+            globals: false
+          }, {}).done(function (body) {
+            assert.deepEqual(body, {});
+            //done();
+          });
+
+          globalize.afterSuccess.call(sample, {
+            globals: {
+                afterSuccess: false
+            }
+          }, {}).done(function (body) {
+            assert.deepEqual(body, {});
+            done();
+          });
+        });
+
+    });
+
+    describe('#afterFailure', function () {
+
+        it('should run the global before method when declared', function (done) {
+          var sample = {
+            _globalOptions: {
+              afterFailure: function (err) {
+                err.code = 'oauth_refresh';
+              }
+            }
+          };
+
+          globalize.afterFailure.call(sample, {}, {}).done(function (err) {
+            assert.deepEqual(err, { code: 'oauth_refresh' });
+            done();
+          });
+        });
+
+        it('should allow for a global promise async', function (done) {
+          var sample = {
+            _globalOptions: {
+              afterFailure: function (err) {
+                return when.promise(function (resolve, reject) {
+                  err.code = 'oauth_refresh';
+                  resolve();
+                });
+              }
+            }
+          };
+
+          globalize.afterFailure.call(sample, {}, {}).done(function (err) {
+            assert.deepEqual(err, { code: 'oauth_refresh' });
+            done();
+          });
+        });
+
+        it('should call the global promise before the local one', function (done) {
+          var calledFirst;
+          var calls = 0;
+
+          var sample = {
+            _globalOptions: {
+              afterFailure: function () {
+                if (!calledFirst) calledFirst = 'global';
+                calls++;
+              }
+            }
+          };
+
+          globalize.afterFailure.call(sample, {
+            afterFailure: function() {
+              if (!calledFirst) calledFirst = 'local';
+              calls++
+            }
+          }, {}).done(function() {
+            assert.equal(calledFirst, 'global');
+            assert.equal(calls, 2);
+            done();
+          });
+        });
+
+        it('should not run the global when globals is false', function (done) {
+          var sample = {
+            _globalOptions: {
+              afterFailure: function (err) {
+                err.code = 'oauth_refresh';
+              }
+            }
+          };
+
+          globalize.afterFailure.call(sample, {
+            globals: false
+          }, {}).done(function (err) {
+            assert.deepEqual(err, {});
+            //done();
+          });
+
+          globalize.afterFailure.call(sample, {
+            globals: {
+                afterFailure: false
+            }
+          }, {}).done(function (err) {
+            assert.deepEqual(err, {});
+            done();
+          });
+        });
+
+
+    });
+
+
+    describe('#afterHeaders', function () {
+
+    	it('should run the global before method when declared', function (done) {
+    		var sampleThread = {
+    			_globalOptions: {
+    				afterHeaders: function (error, params, body, res) {
+    					return {
+                            success: true
+                        };
+    				}
+    			}
+    		};
+
+    		globalize.afterHeaders.call(sampleThread, {}, null, {}, {}, {}).done(function (header) {
+    			assert.deepEqual(header, {
+    				success: true
+    			});
+    			done();
+    		});
+    	});
+
+    	it('should allow for a global promise async', function (done) {
+    		var sampleThread = {
+    			_globalOptions: {
+    				afterHeaders: function (error, params, body, res) {
+    					return when.promise(function (resolve, reject) {
+    						resolve({
+                                success: true
+                            });
+    					});
+    				}
+    			}
+    		};
+
+    		globalize.afterHeaders.call(sampleThread, {}, {}).done(function (header) {
+    			assert.deepEqual(header, {
+    				success: true
+    			});
+    			done();
+    		});
+    	});
+
+    	it('should call the global promise before the local one', function (done) {
+    		var calledFirst;
+    		var calls = 0;
+
+    		var sampleThread = {
+    			_globalOptions: {
+    				afterHeaders: function (error, params, body, res) {
+    					calledFirst = calledFirst || 'global';
+    					calls++;
+    				}
+    			}
+    		};
+
+    		globalize.afterHeaders.call(sampleThread, {
+    			afterHeaders: function () {
+    				calledFirst = calledFirst || 'local';
+    				calls++
+    			}
+    		}, {}).done(function (params) {
+    			assert.equal(calledFirst, 'global');
+    			assert.equal(calls, 2);
+    			done();
+    		});
+    	});
+
+        it('should make local take precedence over global via defaultsDeep', function (done) {
+    		var sampleThread = {
+    			_globalOptions: {
+    				afterHeaders: function (error, params, body, res) {
+    					return {
+                            test: 123
+                        };
+    				}
+    			}
+    		};
+
+    		globalize.afterHeaders.call(sampleThread, {
+    			afterHeaders: function () {
+                    return {
+                        test: 456
+                    };
+    			}
+    		}, {}).done(function (headers) {
+    			assert.equal(headers.test, 456);
+    			done();
+    		});
+    	});
+
+    	it('should not run the globals when globals is false', function (done) {
+    		var sampleThread = {
+    			_globalOptions: {
+    				afterHeaders: function (error, params, body, res) {
+                        return {
+                            success: true
+                        };
+    				}
+    			}
+    		};
+
+    		globalize.afterHeaders.call(sampleThread, {
+    			globals: false
+    		}, {}).done(function (headers) {
+    			assert.deepEqual(headers, {});
+    			//done();
+    		});
+
+    		globalize.afterHeaders.call(sampleThread, {
+    			globals: {
+    				afterHeaders: false
+    			}
+    		}, {}).done(function (headers) {
+    			assert.deepEqual(headers, {});
+    			done();
+    		});
+    	});
+
+    });
 
 });


### PR DESCRIPTION
NOTE: this release will need to coincide with a falafel update

- Breaking change - response format
All methods (including function methods) will now return the following format:
```json
{
    "headers": {},
    "body":  {}
}
```
- `afterHeaders` is now a new property in the REST and SOAP template which runs after `afterSuccess` or `afterFailure`, allowing the `headers` part of the response to be specified
```javascript
{
    afterHeaders: function (error, params, body, res) {
        return {};
    }
}
```

- Minor version bump