### PR TITLE
CPS-131: Require return from before/beforeRequest

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,10 @@ module.exports = function (grunt) {
   grunt.initConfig({
 
     jshint: {
-      all: ['Gruntfile.js', 'lib/**/*.js', 'test/*.js']
+      all: ['Gruntfile.js', 'lib/**/*.js', 'test/*.js'],
+      options: {
+          esversion: 7
+      }
     },
 
     // Configure a mochaTest task

--- a/lib/addMethod/globalize/before.js
+++ b/lib/addMethod/globalize/before.js
@@ -18,7 +18,8 @@ function validateForObject (referenceParams, originalParamsCopy) {
     return (returnedParams) => {
         if (_.isUndefined(returnedParams)) {
             if (process.env.NODE_ENV === 'development' && !_.isEqual(referenceParams, originalParamsCopy)) {
-                console.warn('`before` must return the modified object.');
+                console.warn('`before` must return the modified object. Modification by reference is deprecated.');
+                // throw new Error('`before` must return the modified object. Modification by reference is deprecated.');
             }
         } else if (!_.isPlainObject(returnedParams)) {
             throw new Error('`before` must return an object');

--- a/lib/addMethod/globalize/before.js
+++ b/lib/addMethod/globalize/before.js
@@ -10,16 +10,21 @@ const _    = require('lodash');
 
 const localOnly = require('./localOnly');
 
-function validateForObject (referenceParams, originalParamsCopy) {
+const REFERENCE_MODIFICATION_ERROR_MESSAGE = 'Modification by reference is deprecated. `before` must return the modified object.';
+
+function validateForObject (referencedParams, originalParamsCopy) {
     /*
         If function returns undefined, then assume no modification to
         original params, and so set as default argument
     */
     return (returnedParams) => {
         if (_.isUndefined(returnedParams)) {
-            if (process.env.NODE_ENV === 'development' && !_.isEqual(referenceParams, originalParamsCopy)) {
-                console.warn('`before` must return the modified object. Modification by reference is deprecated.');
-                // throw new Error('`before` must return the modified object. Modification by reference is deprecated.');
+            if (!_.isEqual(referencedParams, originalParamsCopy)) {
+                if (process.env.NODE_ENV === 'development') {
+                    throw new Error(REFERENCE_MODIFICATION_ERROR_MESSAGE);
+                } else {
+                    console.warn(REFERENCE_MODIFICATION_ERROR_MESSAGE);
+                }
             }
         } else if (!_.isPlainObject(returnedParams)) {
             throw new Error('`before` must return an object');

--- a/lib/addMethod/globalize/before.js
+++ b/lib/addMethod/globalize/before.js
@@ -5,36 +5,49 @@
 * object - need to ensure that variables are passed and saved correctly in the
 * tests pre substitution.
 */
-var when = require('when');
-var _    = require('lodash');
+const when = require('when');
+const _    = require('lodash');
 
-var localOnly = require('./localOnly');
+const localOnly = require('./localOnly');
 
-module.exports = function (config, params) {
-  var threadneedle = this;
-  return when.promise(function (resolve, reject) {
-
-    when()
-
-    // Run global promise first
-    .then(function () {
-        if (_.isFunction(threadneedle._globalOptions.before) && !localOnly(config, 'before')) {
-            return when(threadneedle._globalOptions.before(params));
+function validateForObject (referenceParams, originalParamsCopy) {
+    /*
+        If function returns undefined, then assume no modification to
+        original params, and so set as default argument
+    */
+    return (returnedParams) => {
+        if (_.isUndefined(returnedParams)) {
+            if (process.env.NODE_ENV === 'development' && !_.isEqual(referenceParams, originalParamsCopy)) {
+                console.warn('`before` must return the modified object.');
+            }
+        } else if (!_.isPlainObject(returnedParams)) {
+            throw new Error('`before` must return an object');
         }
+        return returnedParams || originalParamsCopy;
+    };
+}
+
+module.exports = function (config, params = {}) {
+
+    const { _globalOptions } = this;
+
+    const originalParams = _.cloneDeep(params);
+
+    //Start by executing globalBefore if provided and globals true
+    const globalBeforeExec = (
+    	_.isFunction(_globalOptions.before) && !localOnly(config, 'before') ?
+    	_globalOptions.before(params) :
+    	params
+    );
+
+    return when(globalBeforeExec)
+
+    .then(validateForObject(params, originalParams))
+
+    .then((globalParamsResult = params) => {
+        return when(( config.before ? config.before(globalParamsResult) : globalParamsResult ));
     })
 
-    // Then run the local prmoise
-    .then(function () {
-      if (_.isFunction(config.before)) {
-        return when(config.before(params));
-      }
-    })
+    .then(validateForObject(params, originalParams));
 
-    .then(function () {
-      return params;
-    })
-
-    .done(resolve, reject);
-
-  });
 };

--- a/lib/addMethod/globalize/beforeRequest.js
+++ b/lib/addMethod/globalize/beforeRequest.js
@@ -6,16 +6,21 @@ const _    = require('lodash');
 
 const localOnly = require('./localOnly');
 
-function validateForObject (referenceRequest, originalRequestCopy) {
+const REFERENCE_MODIFICATION_ERROR_MESSAGE = 'Modification by reference is deprecated. `beforeRequest` must return the modified object.';
+
+function validateForObject (referencedRequest, originalRequestCopy) {
     /*
         If function returns undefined, then assume no modification to
         original params, and so set as default argument
     */
     return (returnedRequest) => {
         if (_.isUndefined(returnedRequest)) {
-            if (process.env.NODE_ENV === 'development' && !_.isEqual(referenceRequest, originalRequestCopy)) {
-                console.warn('`beforeRequest` must return the modified object. Modification by reference is deprecated.');
-                // throw new Error('`beforeRequest` must return the modified object. Modification by reference is deprecated.');
+            if (!_.isEqual(referencedRequest, originalRequestCopy)) {
+                if (process.env.NODE_ENV === 'development') {
+                    throw new Error(REFERENCE_MODIFICATION_ERROR_MESSAGE);
+                } else {
+                    console.warn(REFERENCE_MODIFICATION_ERROR_MESSAGE);
+                }
             }
         } else if (!_.isPlainObject(returnedRequest)) {
             throw new Error('`beforeRequest` must return an object');

--- a/lib/addMethod/globalize/beforeRequest.js
+++ b/lib/addMethod/globalize/beforeRequest.js
@@ -1,36 +1,84 @@
 /*
 * Run the global `beforeRequest` method, and then the local method.
 */
-var when = require('when');
-var _    = require('lodash');
+const when = require('when');
+const _    = require('lodash');
 
-var localOnly = require('./localOnly');
+const localOnly = require('./localOnly');
 
-module.exports = function (config, request, params) {
-  var threadneedle = this;
-  return when.promise(function (resolve, reject) {
+function validateForObject (referenceRequest, originalRequestCopy) {
+    /*
+        If function returns undefined, then assume no modification to
+        original params, and so set as default argument
+    */
+    return (returnedRequest) => {
+        if (_.isUndefined(returnedRequest)) {
+            if (process.env.NODE_ENV === 'development' && !_.isEqual(referenceRequest, originalRequestCopy)) {
+                console.warn('`beforeRequest` must return the modified object. Modification by reference is deprecated.');
+                // throw new Error('`beforeRequest` must return the modified object. Modification by reference is deprecated.');
+            }
+        } else if (!_.isPlainObject(returnedRequest)) {
+            throw new Error('`beforeRequest` must return an object');
+        }
+        return returnedRequest || originalRequestCopy;
+    };
+}
 
-    when()
+module.exports = function (config, request = {}) {
 
-    // Run global promise first
-    .then(function () {
-      if (_.isFunction(threadneedle._globalOptions.beforeRequest) && !localOnly(config, 'beforeRequest')) {
-        return when(threadneedle._globalOptions.beforeRequest(request, params));
-      }
+    const { _globalOptions } = this;
+
+    const originalRequest = _.cloneDeep(request);
+
+    //Start by executing globalBefore if provided and globals true
+    const globalRequestExec = (
+    	_.isFunction(_globalOptions.beforeRequest) && !localOnly(config, 'beforeRequest') ?
+    	_globalOptions.beforeRequest(request) :
+    	request
+    );
+
+    return when(globalRequestExec)
+
+    .then(validateForObject(request, originalRequest))
+
+    .then((globalRequestResult = request) => {
+        return when(( config.before ? config.before(globalRequestResult) : globalRequestResult ));
     })
 
-    // Then run the local prmoise
-    .then(function () {
-      if (_.isFunction(config.beforeRequest)) {
-        return when(config.beforeRequest(request, params));
-      }
-    })
+    .then(validateForObject(request, originalRequest));
 
-    .then(function () {
-      return request;
-    })
-
-    .done(resolve, reject);
-
-  });
 };
+
+// var when = require('when');
+// var _    = require('lodash');
+//
+// var localOnly = require('./localOnly');
+//
+// module.exports = function (config, request, params) {
+//   var threadneedle = this;
+//   return when.promise(function (resolve, reject) {
+//
+//     when()
+//
+//     // Run global promise first
+//     .then(function () {
+//       if (_.isFunction(threadneedle._globalOptions.beforeRequest) && !localOnly(config, 'beforeRequest')) {
+//         return when(threadneedle._globalOptions.beforeRequest(request, params));
+//       }
+//     })
+//
+//     // Then run the local prmoise
+//     .then(function () {
+//       if (_.isFunction(config.beforeRequest)) {
+//         return when(config.beforeRequest(request, params));
+//       }
+//     })
+//
+//     .then(function () {
+//       return request;
+//     })
+//
+//     .done(resolve, reject);
+//
+//   });
+// };

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -89,7 +89,9 @@ describe('#addMethodREST', function () {
 		before(function(done) {
 			app = express();
 			app.use(bodyParser.json());
-			app.use(bodyParser.urlencoded());
+			app.use(bodyParser.urlencoded({
+			  extended: true
+			}));
 			server = app.listen(4000, done);
 		});
 

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -22,7 +22,7 @@ describe('#addMethodSOAP', function () {
     }
 
     describe('Running', function () {
-
+        this.timeout(30000);
         var threadneedle;
 
         before(function () {
@@ -135,7 +135,7 @@ describe('#addMethodSOAP', function () {
         });
 
         it('should be able to execute a standard SOAP method', function (done) {
-            this.timeout(20000);
+
 
             when(
                 threadneedle['list_events']({})
@@ -152,7 +152,6 @@ describe('#addMethodSOAP', function () {
 
 
         it('should substitute to the url and data with a basic example', function (done) {
-            this.timeout(10000);
 
             when(
                 threadneedle.addMethod(
@@ -297,7 +296,6 @@ describe('#addMethodSOAP', function () {
         });
 
         it('should reject if notExpects function returns error', function (done) {
-            this.timeout(10000);
 
             when(
                 threadneedle.addMethod(
@@ -504,7 +502,7 @@ describe('#addMethodSOAP', function () {
     });
 
     describe('Ad-hoc from REST mode', function () {
-        this.timeout(3000);
+        this.timeout(10000);
 
         it('should be fine with allowing a single SOAP method config from REST mode', function (done) {
 

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -2,7 +2,6 @@ var assert       = require('assert');
 var _            = require('lodash');
 var when            = require('when');
 var express      = require('express');
-var bodyParser   = require('body-parser');
 var when         = require('when');
 var fs           = require('fs');
 var randString   = require('mout/random/randString');

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -260,7 +260,7 @@ describe('#globalize', function () {
     });
 
 
-    describe.only('#before', function () {
+    describe('#before', function () {
 
         it('should run the global before method when declared', function(done) {
         	var sample = {
@@ -306,7 +306,7 @@ describe('#globalize', function () {
 			});
         });
 
-        it('should use original params if modified but not returned', function(done) {
+        it('should use original params if modified but not returned (and console warn)', function(done) {
 			var sample = {
 				_globalOptions: {
                     before: function(params) {
@@ -324,6 +324,33 @@ describe('#globalize', function () {
 				assert.deepEqual(params, originalParams);
 				done();
 			});
+        });
+
+        it('should throw an error if params is modified but not returned in development mode', function(done) {
+
+            process.env.NODE_ENV = 'development';
+
+            const sample = {
+				_globalOptions: {
+                    before: function(params) {
+        				params.dc = 'us5';
+        			}
+				}
+			};
+
+            const originalParams = {
+				url: '/mydomain'
+			};
+
+			globalize.before.call(sample, {}, _.cloneDeep(originalParams))
+            .then(assert.fail)
+            .catch((modError) => {
+				assert.strictEqual(modError.message, 'Modification by reference is deprecated. `before` must return the modified object.');
+			})
+            .finally(() => {
+                delete process.env.NODE_ENV;
+                done();
+            });
         });
 
         it('should call the global promise before the local one', function (done) {
@@ -404,10 +431,10 @@ describe('#globalize', function () {
 
     });
 
-    describe.only('#beforeRequest', function () {
+    describe('#beforeRequest', function () {
 
         it('should use original request if modified but not returned', function(done) {
-			var sample = {
+			const sample = {
 				_globalOptions: {
                     beforeRequest: function(request) {
         				request.url += '?hello=world';
@@ -425,6 +452,34 @@ describe('#globalize', function () {
 				assert.deepEqual(request, originalRequest);
 				done();
 			});
+        });
+
+        it('should throw an error if request is modified but not returned in development mode', function(done) {
+
+            process.env.NODE_ENV = 'development';
+
+            const sample = {
+				_globalOptions: {
+                    beforeRequest: function(request) {
+        				request.url += '?hello=world';
+        			}
+				}
+			};
+
+            const originalRequest = {
+                method: 'get',
+				url: 'test.com'
+			};
+
+			globalize.beforeRequest.call(sample, {}, _.cloneDeep(originalRequest))
+            .then(assert.fail)
+            .catch((modError) => {
+				assert.strictEqual(modError.message, 'Modification by reference is deprecated. `beforeRequest` must return the modified object.');
+			})
+            .finally(() => {
+                delete process.env.NODE_ENV;
+                done();
+            });
         });
 
     });

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -260,43 +260,70 @@ describe('#globalize', function () {
     });
 
 
-    describe('#before', function () {
+    describe.only('#before', function () {
 
-        it('should run the global before method when declared', function (done) {
-          var sample = {
-            _globalOptions: {
-              before: function (params) {
-                params.dc = 'us5';
-              }
-            }
-          };
+        it('should run the global before method when declared', function(done) {
+        	var sample = {
+        		_globalOptions: {
+        			before: function(params) {
+        				params.dc = 'us5';
+        				return params;
+        			}
+        		}
+        	};
 
-          globalize.before.call(sample, {}, {
-            url: '/mydomain'
-          }).done(function (params) {
-            assert.deepEqual(params, { url: '/mydomain', dc: 'us5' });
-            done();
-          });
+        	globalize.before.call(sample, {}, {
+        		url: '/mydomain'
+        	}).done(function(params) {
+        		assert.deepEqual(params, {
+        			url: '/mydomain',
+        			dc: 'us5'
+        		});
+        		done();
+        	});
         });
 
-        it('should allow for a global promise async', function (done) {
-          var sample = {
-            _globalOptions: {
-              before: function (params) {
-                return when.promise(function (resolve, reject) {
-                  params.dc = 'us5';
-                  resolve();
-                });
-              }
-            }
-          };
+        it('should allow for a global promise async', function(done) {
+			var sample = {
+				_globalOptions: {
+					before: function(params) {
+						return when.promise(function(resolve, reject) {
+							params.dc = 'us5';
+							resolve(params);
+						});
+					}
+				}
+			};
 
-          globalize.before.call(sample, {}, {
-            url: '/mydomain'
-          }).done(function (params) {
-            assert.deepEqual(params, { url: '/mydomain', dc: 'us5' });
-            done();
-          });
+			globalize.before.call(sample, {}, {
+				url: '/mydomain'
+			}).done(function(params) {
+				assert.deepEqual(params, {
+					url: '/mydomain',
+					dc: 'us5'
+				});
+				done();
+			});
+        });
+
+        it('should use original params if modified but not returned', function(done) {
+			var sample = {
+				_globalOptions: {
+                    before: function(params) {
+        				params.dc = 'us5';
+        			}
+				}
+			};
+
+            const originalParams = {
+				url: '/mydomain'
+			};
+
+			globalize.before.call(sample, {}, _.cloneDeep(originalParams))
+            .done(function(params) {
+				assert.deepEqual(params, originalParams);
+				done();
+			});
         });
 
         it('should call the global promise before the local one', function (done) {

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -404,8 +404,28 @@ describe('#globalize', function () {
 
     });
 
-    describe.skip('#beforeRequest', function () {
+    describe.only('#beforeRequest', function () {
 
+        it('should use original request if modified but not returned', function(done) {
+			var sample = {
+				_globalOptions: {
+                    beforeRequest: function(request) {
+        				request.url += '?hello=world';
+        			}
+				}
+			};
+
+            const originalRequest = {
+                method: 'get',
+				url: 'test.com'
+			};
+
+			globalize.beforeRequest.call(sample, {}, _.cloneDeep(originalRequest))
+            .done(function(request) {
+				assert.deepEqual(request, originalRequest);
+				done();
+			});
+        });
 
     });
 


### PR DESCRIPTION
This update deprecates modification by reference and requires returning if modification is to be passed on.