### PR TITLE
CPS-150: global modification passing bug

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         'mocha': true,
     },
     'parserOptions': {
-        'ecmaVersion': 2017
+        'ecmaVersion': 2018
     },
     'extends': 'eslint:recommended',
     'globals': {

--- a/lib/addMethod/globalize/validateObjectArgumentByReference.js
+++ b/lib/addMethod/globalize/validateObjectArgumentByReference.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 
 module.exports = function (referenceModificationErrorMessage, nonObjectErrorMessage) {
 	return (referencedObject) => {
-		const originalObjectCopy = _.cloneDeep(referencedObject);
+		let referencedObjectCopy = _.cloneDeep(referencedObject);
 		/*
 			If function returns undefined, then default behaviour assumes no
 			modification to	original object and it is passed on. In the event
@@ -10,8 +10,9 @@ module.exports = function (referenceModificationErrorMessage, nonObjectErrorMess
 			Else, ensure returned value is an object.
 		*/
 		return (returnedObject) => {
+			// console.log('returnedObject', returnedObject);
 			if (_.isUndefined(returnedObject)) {
-				if (!_.isEqual(referencedObject, originalObjectCopy)) {
+				if (!_.isEqual(referencedObject, referencedObjectCopy)) {
 					if (process.env.NODE_ENV === 'development') {
 						throw new Error(referenceModificationErrorMessage);
 					} else {
@@ -22,15 +23,22 @@ module.exports = function (referenceModificationErrorMessage, nonObjectErrorMess
 					}
 				}
 				/*
-					Need another cloneDeep, else originalObjectCopy variable
+					Need another cloneDeep, else referencedObjectCopy variable
 					becomes a reference for method config's function
 				*/
 				/*
 					TODO: introduce breaking change to introduce via a flag
 					(which also avoids the return of the reference object above)
 				*/
-				return _.cloneDeep(originalObjectCopy);
+				return _.cloneDeep(referencedObjectCopy);
 			} else if (_.isPlainObject(returnedObject)) {
+				/*
+					 If an object is returned, at this point the
+					 referencedObject should be updated to reflect the returned
+					 object, as this is the object to be used moving forward
+				 */
+				referencedObject = returnedObject;
+				referencedObjectCopy = _.cloneDeep(returnedObject);
 				return returnedObject;
 			}
 			throw new Error(nonObjectErrorMessage);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/threadneedle",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/threadneedle",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "A framework for simplifying working with HTTP-based APIs.",
   "main": "lib/index.js",
   "directories": {

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -511,7 +511,7 @@ describe.only('#globalize', function () {
 				{
 					_globalOptions: {
 						before: function (params) {
-							return {
+							return { //new object instead of same referebce object
 								...params,
 								notes: 'Hello'
 							};
@@ -918,7 +918,7 @@ describe.only('#globalize', function () {
 					_globalOptions: {
 						beforeRequest: function (request) {
 							const url = request.url +  '?hello=world';
-							return {
+							return { //new object instead of same referebce object
 								...request,
 								url
 							};

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -20,7 +20,7 @@ function handleDevFlagTest (testMessage, testFunction) {
 	});
 }
 
-describe('#globalize', function () {
+describe.only('#globalize', function () {
 
 	describe('#url', function () {
 
@@ -340,6 +340,43 @@ describe('#globalize', function () {
 			.then(done, done);
 		});
 
+		it('should run normally with global first and then method - new object', function (done) {
+			globalize.before.call(
+				{
+					_globalOptions: {
+						before: function (params) {
+							return {
+								...params,
+								notes: 'Hello'
+							};
+						}
+					}
+				},
+				{
+					before: function (params) {
+						if (!params.notes) {
+							throw new Error('notes does not exist');
+						}
+						return {
+							...params,
+							description: 'World'
+						};
+					}
+				},
+				{
+					id: 'abc123'
+				}
+			)
+			.then(function (params) {
+				assert.deepEqual(params, {
+					id: 'abc123',
+					notes: 'Hello',
+					description: 'World'
+				});
+			})
+			.then(done, done);
+		});
+
 		it('should run async normally with global first and then method', function (done) {
 			globalize.before.call(
 				{
@@ -460,6 +497,47 @@ describe('#globalize', function () {
 				})
 				.then(done, done);
 			});
+
+		});
+
+		it('should pass on global modification even if method is undefined', function (done) {
+
+			const originalParams = {
+				id: 'abc123',
+				notes: ''
+			};
+
+			globalize.before.call(
+				{
+					_globalOptions: {
+						before: function (params) {
+							return {
+								...params,
+								notes: 'Hello'
+							};
+						}
+					}
+				},
+				{
+					before: function (params) {
+						if (!params.notes) {
+							throw new Error('notes does not exist in params');
+						}
+						assert(params.notes);
+					}
+				},
+				_.cloneDeep(originalParams)
+			)
+			.then(function (params) {
+				assert.deepEqual(
+					params,
+					{
+						id: 'abc123',
+						notes: 'Hello'
+					}
+				);
+			})
+			.then(done, done);
 
 		});
 
@@ -643,6 +721,59 @@ describe('#globalize', function () {
 			.then(done, done);
 		});
 
+		it('should run normally with global first and then method - new object', function (done) {
+
+			const sampleParams = {
+				user_id: 123
+			};
+
+			const sampleGlobal = {
+				_globalOptions: {
+					beforeRequest: function (request, params) {
+						assert.deepEqual(params, sampleParams);
+						const url = request.url +  '?hello=world';
+						return {
+							method: 'get',
+							url
+						};
+					}
+				}
+			};
+
+			const sampleMethodConfig = {
+				beforeRequest: function (request, params) {
+					assert.deepEqual(params, sampleParams);
+					assert(request.url);
+					request.url += '&test=123';
+					return {
+						...request,
+						data: {}
+					};
+				}
+			};
+
+			globalize.beforeRequest.call(
+				sampleGlobal,
+				sampleMethodConfig,
+				{
+					method: 'get',
+					url: 'test.com'
+				},
+				sampleParams
+			)
+			.then(function (request) {
+				assert.deepEqual(
+					request,
+					{
+						method: 'get',
+						url: 'test.com?hello=world&test=123',
+						data: {}
+					}
+				);
+			})
+			.then(done, done);
+		});
+
 		it('should run async normally with  global first and then method', function (done) {
 			const sampleGlobal = {
 				_globalOptions: {
@@ -772,6 +903,47 @@ describe('#globalize', function () {
 				})
 				.then(done, done);
 			});
+
+		});
+
+		it('should pass on global modification even if method is undefined', function (done) {
+
+			const originalRequest = {
+				method: 'get',
+				url: 'test.com'
+			};
+
+			globalize.beforeRequest.call(
+				{
+					_globalOptions: {
+						beforeRequest: function (request) {
+							const url = request.url +  '?hello=world';
+							return {
+								...request,
+								url
+							};
+						}
+					}
+				},
+				{
+					beforeRequest: function (request) {
+						if (!request.url) {
+							throw new Error('url does not exist in request object');
+						}
+					}
+				},
+				_.cloneDeep(originalRequest)
+			)
+			.then(function (request) {
+				assert.deepEqual(
+					request,
+					{
+						method: 'get',
+						url: 'test.com?hello=world'
+					}
+				);
+			})
+			.then(done, done);
 
 		});
 


### PR DESCRIPTION
If the global `before` / `beforeRequest` modifies their respective object, and the method `before` / `beforeRequest` function does not modify and therefore returns undefined, the global’s modification does not get passed on. This PR fixes this issue.