### PR TITLE
CPS-157: object reference decoupling bug

### DIFF
--- a/lib/addMethod/globalize/validateObjectArgumentByReference.js
+++ b/lib/addMethod/globalize/validateObjectArgumentByReference.js
@@ -17,19 +17,11 @@ module.exports = function (referenceModificationErrorMessage, nonObjectErrorMess
 					} else {
 						// eslint-disable-next-line no-console
 						console.warn(referenceModificationErrorMessage);
-						//Maintain backwards compatibility in non-dev mode
-						return referencedObject;
 					}
 				}
-				/*
-					Need another cloneDeep, else referencedObjectCopy variable
-					becomes a reference for method config's function
-				*/
-				/*
-					TODO: introduce breaking change to introduce via a flag
-					(which also avoids the return of the reference object above)
-				*/
-				return _.cloneDeep(referencedObjectCopy);
+				//Maintain backwards compatibility in non-dev mode
+				referencedObjectCopy = _.cloneDeep(referencedObject);
+				return referencedObject;
 			} else if (_.isPlainObject(returnedObject)) {
 				/*
 					 If an object is returned, at this point the

--- a/lib/addMethod/globalize/validateObjectArgumentByReference.js
+++ b/lib/addMethod/globalize/validateObjectArgumentByReference.js
@@ -19,7 +19,13 @@ module.exports = function (referenceModificationErrorMessage, nonObjectErrorMess
 						console.warn(referenceModificationErrorMessage);
 					}
 				}
-				//Maintain backwards compatibility in non-dev mode
+				/*
+					Maintain backwards compatibility in non-dev mode. Update
+					copy for 2nd time validation.
+					Threadneedle v2 (breaking change) needs to change this to
+					`return _.cloneDeep(referencedObjectCopy);` or similar -
+					i.e. on undefined, pass on original/prior `params`
+				*/
 				referencedObjectCopy = _.cloneDeep(referencedObject);
 				return referencedObject;
 			} else if (_.isPlainObject(returnedObject)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/threadneedle",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/threadneedle",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "A framework for simplifying working with HTTP-based APIs.",
   "main": "lib/index.js",
   "directories": {

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -652,7 +652,7 @@ describe('#globalize', function () {
 
 		});
 
-		describe.only('should throw an error if params is modified but not returned in development mode', function () {
+		describe('should throw an error if params is modified but not returned in development mode', function () {
 
 			const sampleMethodConfig = {
 				before: function (params) {

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -448,7 +448,7 @@ describe('#globalize', function () {
 				notes: ''
 			};
 
-			it('global', function (done) {
+			it('global - no local `before`', function (done) {
 				globalize.before.call(sampleGlobal, {}, _.cloneDeep(originalParams))
 				.then(function (params) {
 					assert.deepEqual(
@@ -462,9 +462,41 @@ describe('#globalize', function () {
 				.then(done, done);
 			});
 
-			it('method', function (done) {
+			it('global - non-returning local `before`', function (done) {
+				globalize.before.call(sampleGlobal, { before: () => {} }, _.cloneDeep(originalParams))
+				.then(function (params) {
+					assert.deepEqual(
+						params,
+						{
+							id: 'abc123',
+							notes: 'Hello'
+						}
+					);
+				})
+				.then(done, done);
+			});
+
+			it('method - empty global', function (done) {
 				globalize.before.call(
 					{ _globalOptions: {} },
+					sampleMethodConfig,
+					_.cloneDeep(originalParams)
+				)
+				.then(function (params) {
+					assert.deepEqual(
+						params,
+						{
+							id: 'abc123',
+							notes: ' World'
+						}
+					);
+				})
+				.then(done, done);
+			});
+
+			it('method - non-returning global `before`', function (done) {
+				globalize.before.call(
+					{ _globalOptions: { before: () => {} } },
 					sampleMethodConfig,
 					_.cloneDeep(originalParams)
 				)


### PR DESCRIPTION
`validateObjectArgumentByReference` now returns the original reference object when the `returnedObject` is `undefined`.

- `before` and `beforeRequest` tests updated.
- added dedicated tests for `validateObjectArgumentByReference`.