### PR TITLE
CPS-158: `type` flag introduction

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 # Credentials
-dummycredentials.json
 
 #Test Files
 tests*

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ If there is meta data that needs to be specified with every `REST template` meth
 As of v1.3.0, threadneedle has added support for SOAP, on both a global and method level.
 The library used is [node-soap](https://github.com/vpulim/node-soap)
 
-This mode can be initialised by adding the following flag to the (global) model: `soap: true`.
+This mode can be initialised by adding the following flag to the (global) model: `type: 'SOAP'`.
 If the flag is set on the global level, then threadneedle will only accept valid SOAP objects and functions as methods (and REST will not be supported). However, if the flag is only used by a method, then only the method will be in SOAP mode, but will expect all required fields to be provided.
 
 ### Global fields

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -20,13 +20,13 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 	var threadneedle = this;
 
 	//If one-off SOAP mode, then perform addMethodSOAP instead
-	if (config && (config.type === 'soap' || config.soap)) {
+	if (_.isPlainObject(config) && ((_.isString(config.type) && config.type.toLowerCase() === 'soap') || config.soap)) {
 		if (config.soap) {
 			//eslint-disable-next-line no-console
-			console.warn('`soap` flag has been deprecated. Use `type: \'SOAP\'` instead.');
+			console.warn(methodName + ': `soap` flag has been deprecated. Use `type: \'SOAP\'` instead.');
 		}
 		config.globals = false;
-		threadneedle[methodName] = require('./addMethodSOAP').call({ _globalOptions: {} }, methodName, config);
+		threadneedle[methodName] = require('./addMethodSOAP').call({ _globalOptions: { type: 'soap' } }, methodName, config);
 		return;
 	}
 

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -26,238 +26,236 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 		return;
 	}
 
-  // All methods should default to no timeout, maximising the chance
-  // of success.
-  needle.defaults({
-	open_timeout: 0,
-	read_timeout: 0
-  });
+	// All methods should default to no timeout, maximising the chance
+	// of success.
+	needle.defaults({
+		open_timeout: 0,
+		read_timeout: 0
+	});
 
-  // Validate the input. Errors will be `throw`n if there's anything
-  // wrong. Throwing is usually bad - but this is declarative, so will happen
-  // on app startup;
-  validateInput.call(this, methodName, config);
+	// Validate the input. Errors will be `throw`n if there's anything
+	// wrong. Throwing is usually bad - but this is declarative, so will happen
+	// on app startup;
+	validateInput.call(this, methodName, config);
 
-  // Create the method
-  threadneedle[methodName] = function (params) {
+	// Create the method
+	threadneedle[methodName] = function (params) {
 
-	params = params || {};
+		params = params || {};
 
-	/*
+		/*
 	  Override - if a function is provided as config, then simply run it - don't run HTTP requests.
 	  It should expect a promise returned by the function. Pass the context
 	*/
-	if (_.isFunction(config)) {
-	  logger.info(methodName+': Running method function.');
-	  return addMethodFunction(threadneedle, config, afterHeadersFunction, params);
-	}
-
-
-	return when.promise(function (resolve, reject) {
-
-		//Handle afterHeader for resolving
-		function afterHeadersResolve (body, result) {
-
-			logger.info(methodName+': running `afterHeaders` hook');
-			globalize.afterHeaders.call(threadneedle, config, null, body, params, result.response)
-
-			.done(
-				function (headers) {
-					resolve(formatResponse(headers, body));
-				},
-				function (error) {
-					reject(formatResponse({}, error));
-				}
-			);
-
+		if (_.isFunction(config)) {
+			logger.info(methodName+': Running method function.');
+			return addMethodFunction(threadneedle, config, afterHeadersFunction, params);
 		}
 
-		//Handle afterHeader for rejecting
-		function afterHeadersReject (error, payload, response) {
 
-			logger.info(methodName+': running `afterHeaders` hook');
-			globalize.afterHeaders.call(threadneedle, config, error, payload, params, response)
+		return when.promise(function (resolve, reject) {
 
-			.done(
-				function (headers) {
-					reject(formatResponse(headers, error));
-				},
-				function (err) {
-					reject(formatResponse({}, err || error));
+			//Handle afterHeader for resolving
+			function afterHeadersResolve (body, result) {
+
+				logger.info(methodName+': running `afterHeaders` hook');
+				globalize.afterHeaders.call(threadneedle, config, null, body, params, result.response)
+
+				.done(
+					function (headers) {
+						resolve(formatResponse(headers, body));
+					},
+					function (error) {
+						reject(formatResponse({}, error));
+					}
+				);
+
+			}
+
+			//Handle afterHeader for rejecting
+			function afterHeadersReject (error, payload, response) {
+
+				logger.info(methodName+': running `afterHeaders` hook');
+				globalize.afterHeaders.call(threadneedle, config, error, payload, params, response)
+
+				.done(
+					function (headers) {
+						reject(formatResponse(headers, error));
+					},
+					function (err) {
+						reject(formatResponse({}, err || error));
+					}
+				);
+
+			}
+
+			// Method, always lowercased
+			var method = config.method.toLowerCase();
+
+			// Kick off that promise chain
+			when()
+
+			// Run a `before` if set on the params.
+			.then(function () {
+				logger.info('Running method `'+methodName+'` `before`.');
+				return globalize.before.call(threadneedle, config, params);
+			})
+
+			// Set a bunch of local variables, formatted and templated
+			.then(function (result) {
+				params = result;
+
+				logger.info(methodName+': substituting parameters');
+
+				// Add a temp file parameter for file handling operations
+				if (config.fileHandler === true) {
+					params.temp_file = '/tmp/'+guid();
 				}
-			);
 
-		}
+				// The URL endpoint. Query parameters allowed from here.
+				var url = globalize.baseUrl.call(threadneedle, config, params);
+				// var url = globalize.call(threadneedle, config.globals, 'url', config, params);
 
-		// Method, always lowercased
-		var method = config.method.toLowerCase();
-
-		// Kick off that promise chain
-		when()
-
-		// Run a `before` if set on the params.
-		.then(function () {
-			logger.info('Running method `'+methodName+'` `before`.');
-			return globalize.before.call(threadneedle, config, params);
-		})
-
-		// Set a bunch of local variables, formatted and templated
-		.then(function (result) {
-			params = result;
-
-			logger.info(methodName+': substituting parameters');
-
-			// Add a temp file parameter for file handling operations
-			if (config.fileHandler === true) {
-			  params.temp_file = '/tmp/'+guid();
-			}
-
-			// The URL endpoint. Query parameters allowed from here.
-			var url = globalize.baseUrl.call(threadneedle, config, params);
-			// var url = globalize.call(threadneedle, config.globals, 'url', config, params);
-
-			// Add query parameters intelligently, without conflicting from query parameters
-			// already specified in the URL.
-			var query = globalize.object.call(threadneedle, 'query', config, params);
-			_.each(query, function (value, key) {
-			  if (_.isArray(value) && value.length > 0) {
-				value = value.join(',');
-			  }
-			  if (!_.isUndefined(value) && !(_.isString(value) && value === '')) {
-				url = setParam(url, key, value);
-			  }
-			});
-
-			// The request options, substituted
-			var options = globalize.object.call(threadneedle, 'options', config, params);
-
-			// Post/put/delete data
-			var data;
-			switch (method) {
-				case 'get':
-				case 'head':
-					break;
-				default:
-					data = globalize.object.call(threadneedle, 'data', config, params);
-			}
-
-			return {
-			  url: url,
-			  data: data,
-			  options: options,
-			  method: method
-			};
-		})
-
-		// Run the `beforeRequest`
-		.then(function (request) {
-			logger.info(methodName+': running `beforeRequest` hook');
-			return globalize.beforeRequest.call(threadneedle, config, request, params);
-		})
-
-		// Run the actual request
-		.then(function (request) {
-		  return when.promise(function(resolve, reject) {
-
-				var handleResponse = function(err, res, body) {
-
-					function handleReject(payload) {
-						return reject({
-							payload: payload,
-							response: res
-						});
+				// Add query parameters intelligently, without conflicting from query parameters
+				// already specified in the URL.
+				var query = globalize.object.call(threadneedle, 'query', config, params);
+				_.each(query, function (value, key) {
+					if (_.isArray(value) && value.length > 0) {
+						value = value.join(',');
 					}
-
-					if (err) {
-
-						// Specifically handle socket hang ups nicely
-						if (_.isError(err) && err.message === 'socket hang up') {
-							return handleReject( {
-								code: 'api_timeout',
-								response: {},
-								message: 'API call timeout. Looks like the API you\'re calling is having a wobble. Please try again later.'
-							});
-						}
-
-						else {
-							return handleReject(err);
-						}
-
-					} else {
-
-						logger.info(methodName + ': got response', res.statusCode, JSON.stringify(body));
-
-						var validationError;
-
-						// Validate `expects`
-						var expects = globalize.expects.call(threadneedle, config);
-						validationError = validateExpects(res, expects);
-						if (validationError){
-							return handleReject(validationError);
-						}
-
-						// Validate `notExpects`
-						var notExpects = globalize.notExpects.call(threadneedle, config);
-						validationError = validateNotExpects(res, notExpects);
-						if (validationError){
-							return handleReject(validationError);
-						}
-
-						// We're valid!
-						resolve({
-							body: body,
-							response: res
-						});
-
+					if (!_.isUndefined(value) && !(_.isString(value) && value === '')) {
+						url = setParam(url, key, value);
 					}
-				};
+				});
 
-				// console.log(options);
-				logger.info(methodName + ': running ' + method + ' request', request);
+				// The request options, substituted
+				var options = globalize.object.call(threadneedle, 'options', config, params);
 
-				// Run a different method for get to not include data
+				// Post/put/delete data
+				var data;
 				switch (method) {
 					case 'get':
 					case 'head':
-						needle[method](request.url, request.options, handleResponse);
 						break;
 					default:
-						needle[method](request.url, request.data, request.options, handleResponse);
+						data = globalize.object.call(threadneedle, 'data', config, params);
 				}
 
-		  });
-		})
+				return {
+					url: url,
+					data: data,
+					options: options,
+					method: method
+				};
+			})
 
-		// Handle the after success and failure messages
-		.done(
-			function (result) {
+			// Run the `beforeRequest`
+			.then(function (request) {
+				logger.info(methodName+': running `beforeRequest` hook');
+				return globalize.beforeRequest.call(threadneedle, config, request, params);
+			})
 
-				logger.info(methodName + ': running `afterSuccess` hook');
-				globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
-				.done(
-					function (body) { afterHeadersResolve(body, result); },
-					function (error) { afterHeadersReject(error, result.body, result.response); }
-				);
+			// Run the actual request
+			.then(function (request) {
+				return when.promise(function (resolve, reject) {
 
-			},
-			function (err) {
+					var handleResponse = function (err, res, body) {
 
-				var payload = (err.payload ? err.payload : err),
-					response = (err.response ? err.response : {});
+						function handleReject (payload) {
+							return reject({
+								payload: payload,
+								response: res
+							});
+						}
 
-				function rejectAfterHeaders(error) {
-					afterHeadersReject(error, payload, response);
+						if (err) {
+
+							// Specifically handle socket hang ups nicely
+							if (_.isError(err) && err.message === 'socket hang up') {
+								return handleReject( {
+									code: 'api_timeout',
+									response: {},
+									message: 'API call timeout. Looks like the API you\'re calling is having a wobble. Please try again later.'
+								});
+							} else {
+								return handleReject(err);
+							}
+
+						} else {
+
+							logger.info(methodName + ': got response', res.statusCode, JSON.stringify(body));
+
+							var validationError;
+
+							// Validate `expects`
+							var expects = globalize.expects.call(threadneedle, config);
+							validationError = validateExpects(res, expects);
+							if (validationError) {
+								return handleReject(validationError);
+							}
+
+							// Validate `notExpects`
+							var notExpects = globalize.notExpects.call(threadneedle, config);
+							validationError = validateNotExpects(res, notExpects);
+							if (validationError) {
+								return handleReject(validationError);
+							}
+
+							// We're valid!
+							resolve({
+								body: body,
+								response: res
+							});
+
+						}
+					};
+
+					// console.log(options);
+					logger.info(methodName + ': running ' + method + ' request', request);
+
+					// Run a different method for get to not include data
+					switch (method) {
+						case 'get':
+						case 'head':
+							needle[method](request.url, request.options, handleResponse);
+							break;
+						default:
+							needle[method](request.url, request.data, request.options, handleResponse);
+					}
+
+				});
+			})
+
+			// Handle the after success and failure messages
+			.done(
+				function (result) {
+
+					logger.info(methodName + ': running `afterSuccess` hook');
+					globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
+					.done(
+						function (body) { afterHeadersResolve(body, result); },
+						function (error) { afterHeadersReject(error, result.body, result.response); }
+					);
+
+				},
+				function (err) {
+
+					var payload = (err.payload ? err.payload : err),
+						response = (err.response ? err.response : {});
+
+					function rejectAfterHeaders (error) {
+						afterHeadersReject(error, payload, response);
+					}
+
+					logger.info(methodName + ': running `afterFailure` hook', err);
+					globalize.afterFailure.call(threadneedle, config, payload, params, response)
+					.done(rejectAfterHeaders, rejectAfterHeaders);
+
 				}
+			);
 
-				logger.info(methodName + ': running `afterFailure` hook', err);
-				globalize.afterFailure.call(threadneedle, config, payload, params, response)
-				.done(rejectAfterHeaders, rejectAfterHeaders);
+		});
 
-			}
-		);
-
-	});
-
-  };
+	};
 
 };

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -20,7 +20,11 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 	var threadneedle = this;
 
 	//If one-off SOAP mode, then perform addMethodSOAP instead
-	if (config && config.soap) {
+	if (config && (config.type === 'soap' || config.soap)) {
+		if (config.soap) {
+			//eslint-disable-next-line no-console
+			console.warn('`soap` flag has been deprecated. Use `type: \'SOAP\'` instead.');
+		}
 		config.globals = false;
 		threadneedle[methodName] = require('./addMethodSOAP').call({ _globalOptions: {} }, methodName, config);
 		return;

--- a/lib/addMethod/getSOAPClient.js
+++ b/lib/addMethod/getSOAPClient.js
@@ -42,6 +42,10 @@ module.exports = function (clientConfig) {
 
 				}
 
+				client.on('request', (xml) => {
+					console.log(xml);
+				});
+
 				return resolve(client);
 
 			}

--- a/lib/addMethod/getSOAPClient.js
+++ b/lib/addMethod/getSOAPClient.js
@@ -10,7 +10,7 @@ module.exports = function (clientConfig) {
 		SOAP.createClient(
 			clientConfig.wsdl,
 			clientConfig.options || {},
-			function(err, client) {
+			function (err, client) {
 
 				if (err) {
 					return reject(err);
@@ -41,10 +41,6 @@ module.exports = function (clientConfig) {
 					}
 
 				}
-
-				client.on('request', (xml) => {
-					console.log(xml);
-				});
 
 				return resolve(client);
 

--- a/lib/addMethod/index.js
+++ b/lib/addMethod/index.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const addMethodREST = require('./addMethodREST');
 const addMethodSOAP = require('./addMethodSOAP');
 
-const INVALID_TYPE_ERROR_MESSAGE = '`type` must be strings \'REST\' or \'SOAP\'';
+const INVALID_TYPE_ERROR_MESSAGE = `\`type\` must be strings 'REST' or 'SOAP'`;
 function validateAndGetType ([ methodName, config ]) {
 	const { type } = config;
 

--- a/lib/addMethod/index.js
+++ b/lib/addMethod/index.js
@@ -1,8 +1,46 @@
+const _ = require('lodash');
 
-module.exports = function (soapFlag) {
-    return (
-        soapFlag ?
-        require('./addMethodSOAP') :
-        require('./addMethodREST')
-    );
+const addMethodREST = require('./addMethodREST');
+const addMethodSOAP = require('./addMethodSOAP');
+
+const INVALID_TYPE_ERROR_MESSAGE = '`type` must be strings \'REST\' or \'SOAP\'';
+function validateAndGetType ([ methodName, type ]) {
+
+	if (!_.isString(type)) {
+		throw new Error(`${methodName}: ${INVALID_TYPE_ERROR_MESSAGE}`);
+	}
+	const lowerCaseType = type.toLowerCase();
+	switch (lowerCaseType) {
+		case 'rest':
+		case 'soap':
+			return lowerCaseType;
+		default:
+			throw new Error(`${methodName}: ${INVALID_TYPE_ERROR_MESSAGE}`);
+	}
+}
+
+module.exports = function (...addMethodArgs) {
+
+	const { type: globalType } = this._globalOptions;
+	const methodConfigType = _.get(addMethodArgs, '[1].type', undefined);
+
+	const targetType = (
+		/*
+			Need to specify soap if global type is soap for backwards
+			compatibility. Remove in Threadneedle v2 and allow operation to
+			specify type regardless of global default.
+		*/
+		globalType === 'soap' ?
+		globalType :
+		( methodConfigType ? validateAndGetType(addMethodArgs) : globalType )
+
+	);
+
+	switch (targetType) {
+		case 'rest': return addMethodREST.call(this, ...addMethodArgs);
+		case 'soap': return addMethodSOAP.call(this, ...addMethodArgs);
+		default:
+			throw new Error(`'Invalid type'`);
+	}
+
 };

--- a/lib/addMethod/index.js
+++ b/lib/addMethod/index.js
@@ -4,7 +4,8 @@ const addMethodREST = require('./addMethodREST');
 const addMethodSOAP = require('./addMethodSOAP');
 
 const INVALID_TYPE_ERROR_MESSAGE = '`type` must be strings \'REST\' or \'SOAP\'';
-function validateAndGetType ([ methodName, type ]) {
+function validateAndGetType ([ methodName, config ]) {
+	const { type } = config;
 
 	if (!_.isString(type)) {
 		throw new Error(`${methodName}: ${INVALID_TYPE_ERROR_MESSAGE}`);

--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -1,4 +1,22 @@
+const _ = require('lodash');
 
 module.exports = function (options) {
-    this._globalOptions = options;
+	const { type } = options;
+	if (!_.isUndefined(type) && _.isString(type)) {
+		const lowerCaseType = type.toLowerCase();
+		switch (lowerCaseType) {
+			case 'rest':
+			case 'soap':
+				options.type = lowerCaseType;
+				break;
+			default:
+				options.type = this._globalOptions.type;
+		}
+	} else {
+		options.type = this._globalOptions.type;
+	}
+	this._globalOptions = {
+		...this._globalOptions,
+		...options
+	};
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 
 const SOAP_FLAG_DEPRECATION_WARNING = '`soap` flag has been deprecated. Use `type: \'SOAP\'` instead.';
 
-
 module.exports = function (soapFlag) {
 
 	if (_.isBoolean(soapFlag) && soapFlag) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,23 @@
 const _ = require('lodash');
 
+const SOAP_FLAG_DEPRECATION_WARNING = '`soap` flag has been deprecated. Use `type: \'SOAP\'` instead.';
+
+
 module.exports = function (soapFlag) {
+
+	if (_.isBoolean(soapFlag) && soapFlag) {
+		if (process.env.NODE_ENV === 'development') {
+			throw new Error(SOAP_FLAG_DEPRECATION_WARNING);
+		} else {
+			//eslint-disable-next-line no-console
+			console.warn(SOAP_FLAG_DEPRECATION_WARNING);
+		}
+	}
 
 	const threadneedle = {
 
 		// The key method
-		addMethod: require('./addMethod')(soapFlag),
+		addMethod: require('./addMethod'),
 
 		// Global hook to set global options below
 		global: require('./global'),
@@ -13,7 +25,8 @@ module.exports = function (soapFlag) {
 		// Default global settings (can be overridden)
 		_globalOptions: {
 
-			type: 'rest' //default type
+			//default type is rest. soapFlag used for backward compatibility
+			type: ( soapFlag ? 'soap' : 'rest' )
 
 			//TODO: Threadneedle v2: default to '2xx' for REST; breaking change
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,28 +1,28 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
 module.exports = function (soapFlag) {
 
-    var threadneedle = {
+	const threadneedle = {
 
-        // The key method
-        addMethod: require('./addMethod')(soapFlag),
+		// The key method
+		addMethod: require('./addMethod')(soapFlag),
 
-        // Global hook to set global options below
-        global: require('./global'),
+		// Global hook to set global options below
+		global: require('./global'),
 
-        // Default global settings (can be overridden)
-        _globalOptions: {
+		// Default global settings (can be overridden)
+		_globalOptions: {
 
-            // TODO Good requests generall come back with a '2xx'
-            // expects: {
-            //   statusCode: 200
-            // }
+			// TODO Good requests generall come back with a '2xx'
+			// expects: {
+			//   statusCode: 200
+			// }
 
-        }
+		}
 
-    };
+	};
 
 
-    return threadneedle;
+	return threadneedle;
 
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,15 +13,13 @@ module.exports = function (soapFlag) {
 		// Default global settings (can be overridden)
 		_globalOptions: {
 
-			// TODO Good requests generall come back with a '2xx'
-			// expects: {
-			//   statusCode: 200
-			// }
+			type: 'rest' //default type
+
+			//TODO: Threadneedle v2: default to '2xx' for REST; breaking change
 
 		}
 
 	};
-
 
 	return threadneedle;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,32 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+    },
+    "@types/node": {
+      "version": "12.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
+      "integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA=="
+    },
+    "@types/request": {
+      "version": "2.48.3",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
+      "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -41,15 +67,15 @@
       }
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "ajv": {
@@ -159,9 +185,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
     },
     "body": {
       "version": "5.1.0",
@@ -377,13 +403,13 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
       }
     },
@@ -394,6 +420,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "content-type": {
@@ -542,11 +576,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "ejs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-      "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -559,13 +588,12 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "error": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.2.0.tgz",
+      "integrity": "sha512-M6t3j3Vt3uDicrViMP5fLq2AeADNrCVFD8Oj4Qt2MHsX0mPYG7D5XdnEfSdRpaHQzjAJ19wu+I1mw9rQYMTAPg==",
       "dev": true,
       "requires": {
-        "string-template": "~0.2.1",
-        "xtend": "~4.0.0"
+        "string-template": "~0.2.1"
       }
     },
     "error-ex": {
@@ -589,9 +617,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
-      "integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -661,12 +689,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -676,13 +704,13 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -782,6 +810,12 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
           "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -858,6 +892,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -902,11 +937,6 @@
         }
       }
     },
-    "first-chunk-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-0.1.0.tgz",
-      "integrity": "sha1-dV0+wU1JqG49L8wIvurVwMornAo="
-    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -930,9 +960,9 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -992,9 +1022,9 @@
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1006,9 +1036,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -1227,9 +1257,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "http-errors": {
@@ -1405,12 +1435,8 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1734,9 +1760,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mustache": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.3.tgz",
-      "integrity": "sha512-vM5FkMHamTYmVYeAujypihuPrJQDtaUIlKeeVb1AMJ73OZLtWiF7GprqrjxD0gJWT53W9JfqXxf97nXQjMQkqA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.1.0.tgz",
+      "integrity": "sha512-3Bxq1R5LBZp7fbFPZzFe5WN4s0q3+gxZaZuZVY+QctYJiCiVgXHOTIC0/HgZuOPFt/6BQcx5u0H2CUOxT/RoGQ=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -1962,11 +1988,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2058,17 +2079,13 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "redent": {
@@ -2121,6 +2138,18 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "resolve": {
@@ -2176,9 +2205,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safe-json-parse": {
       "version": "1.0.1",
@@ -2278,23 +2307,37 @@
       }
     },
     "soap": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/soap/-/soap-0.26.0.tgz",
-      "integrity": "sha512-tTS3lnGl6lfjQQuJgNnWOgC0Xa6qYQSwl2G7DX3kCdGmek/FTNmHDM/7icKP1KBMFfCrKpAWEbZiGefa92SCYw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/soap/-/soap-0.30.0.tgz",
+      "integrity": "sha512-nPDbX8Y/EJNyMXog50BRONUa/S0oaDYvFO3IAegh7IoxOwGpWr6xoyUx+ZgAY9tvstZDnOHRPdfvxDhAVCVyAQ==",
       "requires": {
+        "@types/request": "^2.48.1",
         "bluebird": "^3.5.0",
-        "concat-stream": "^1.5.1",
-        "debug": "^2.6.9",
-        "ejs": "~2.5.5",
-        "finalhandler": "^1.0.3",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.1.1",
         "httpntlm": "^1.5.2",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.15",
         "request": ">=2.9.0",
         "sax": ">=0.6",
         "serve-static": "^1.11.1",
-        "strip-bom": "~0.3.1",
+        "strip-bom": "^3.0.0",
         "uuid": "^3.1.0",
-        "xml-crypto": "~0.8.0"
+        "xml-crypto": "^1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "spdx-correct": {
@@ -2389,11 +2432,11 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -2414,13 +2457,9 @@
       }
     },
     "strip-bom": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-0.3.1.tgz",
-      "integrity": "sha1-noo57/RW/5q8LwWfXyIluw8/fKU=",
-      "requires": {
-        "first-chunk-stream": "^0.1.0",
-        "is-utf8": "^0.2.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -2630,7 +2669,8 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
@@ -2754,29 +2794,23 @@
       }
     },
     "xml-crypto": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-0.8.5.tgz",
-      "integrity": "sha1-K7z7PrM/OoKiGLgiv2craxwg5Tg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-1.4.0.tgz",
+      "integrity": "sha512-K8FRdRxICVulK4WhiTUcJrRyAIJFPVOqxfurA3x/JlmXBTxy+SkEENF6GeRt7p/rB6WSOUS9g0gXNQw5n+407g==",
       "requires": {
-        "xmldom": "=0.1.19",
-        "xpath.js": ">=0.0.3"
+        "xmldom": "0.1.27",
+        "xpath": "0.0.27"
       }
     },
     "xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
-    "xpath.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xpath.js/-/xpath.js-1.1.0.tgz",
-      "integrity": "sha512-jg+qkfS4K8E7965sqaUl8mRngXiKb3WZGfONgE18pr03FUQiuSV6G+Ej4tS55B+rIQSFEIw3phdVAQ4pPqNWfQ=="
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+    "xpath": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
+      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trayio/threadneedle",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "description": "A framework for simplifying working with HTTP-based APIs.",
   "main": "lib/index.js",
   "directories": {
@@ -28,9 +28,9 @@
   "dependencies": {
     "lodash": "~4.17.15",
     "mout": "~1.1.0",
-    "mustache": "~3.0.1",
+    "mustache": "~3.1.0",
     "needle": "~2.1.2",
-    "soap": "~0.26.0",
+    "soap": "~0.30.0",
     "when": "~3.7.8",
     "winston": "~2.4.4"
   },

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -36,7 +36,6 @@ describe('#addMethodREST', function () {
 			assert.strictEqual(caught, 2);
 		});
 
-
 		it('should error when a method already exists for that name', function () {
 			var caught = 0;
 			try {
@@ -74,6 +73,21 @@ describe('#addMethodREST', function () {
 				caught++;
 			}
 			assert.strictEqual(caught, 1);
+		});
+
+		it('should error if `type` is not valid', function () {
+			const privateThreadneedle = new ThreadNeedle();
+			try {
+				privateThreadneedle.addMethod(randString(10), {
+					type: 'test',
+					method: 'get',
+					url: 'http://localhost:4000',
+					expects: 200
+				});
+				assert.fail('Invalid type did not throw an error');
+			} catch (globalError) {
+				assert(globalError.message.includes(`\`type\` must be strings 'REST' or 'SOAP'`));
+			}
 		});
 
 	});

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -121,6 +121,25 @@ describe('#addMethodREST', function () {
 			});
 		});
 
+		it('should work with a basic example and specified type `rest`', function (done) {
+			var name = randString(10);
+			threadneedle.addMethod(name, {
+				type: 'REST',
+				method: 'get',
+				url: host + '/' + name,
+				expects: 200
+			});
+
+			app.get('/' + name, function (req, res) {
+				res.status(200).send('ok');
+			});
+
+			threadneedle[name]().done(function (result) {
+				assert.equal(result.body, 'ok');
+				done();
+			});
+		});
+
 		it('should substitute to the url with a basic example', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {

--- a/tests/addMethodREST_test.js
+++ b/tests/addMethodREST_test.js
@@ -5,20 +5,19 @@ var bodyParser   = require('body-parser');
 var when         = require('when');
 var fs           = require('fs');
 var randString   = require('mout/random/randString');
-var globalize    = require('../lib/addMethod/globalize');
 var ThreadNeedle = require('../');
 
 
 describe('#addMethodREST', function () {
 
-	describe('Validation', function() {
+	describe('Validation', function () {
 
 		var threadneedle;
-		beforeEach(function() {
+		beforeEach(function () {
 			threadneedle = new ThreadNeedle();
 		});
 
-		it('should error when `methodName` isn\'t provided', function() {
+		it('should error when `methodName` isn\'t provided', function () {
 			var caught = 0;
 			try {
 				threadneedle.addMethod();
@@ -38,7 +37,7 @@ describe('#addMethodREST', function () {
 		});
 
 
-		it('should error when a method already exists for that name', function() {
+		it('should error when a method already exists for that name', function () {
 			var caught = 0;
 			try {
 				threadneedle.addMethod('addMethod', {
@@ -52,10 +51,10 @@ describe('#addMethodREST', function () {
 			assert.strictEqual(caught, 1);
 		});
 
-		it('should error when a url isn\'t declared', function() {
+		it('should error when a url isn\'t declared', function () {
 			var caught = 0;
 			try {
-				threadneedle.addMethod('createList', {})
+				threadneedle.addMethod('createList', {});
 			} catch (err) {
 				assert.strictEqual(err.message, 'The `url` config parameter should be declared.');
 				caught++;
@@ -63,13 +62,13 @@ describe('#addMethodREST', function () {
 			assert.strictEqual(caught, 1);
 		});
 
-		it('should error when the method is invalid', function() {
+		it('should error when the method is invalid', function () {
 			var caught = 0;
 			try {
 				threadneedle.addMethod('createList', {
 					url: 'http://yourdomain.com',
 					method: 'chris'
-				})
+				});
 			} catch (err) {
 				assert.strictEqual(err.message, 'The `method` "chris" is not a valid method. Allowed methods are: get, put, post, delete, head, patch');
 				caught++;
@@ -80,31 +79,31 @@ describe('#addMethodREST', function () {
 	});
 
 
-	describe('Running', function() {
+	describe('Running', function () {
 
 		var host = 'http://localhost:4000';
 		var server;
 		var app;
 
-		before(function(done) {
+		before(function (done) {
 			app = express();
 			app.use(bodyParser.json());
 			app.use(bodyParser.urlencoded({
-			  extended: true
+				extended: true
 			}));
 			server = app.listen(4000, done);
 		});
 
-		after(function(done) {
+		after(function (done) {
 			server.close(done);
 		});
 
 		var threadneedle;
-		beforeEach(function() {
+		beforeEach(function () {
 			threadneedle = new ThreadNeedle();
 		});
 
-		it('should work with a basic example', function(done) {
+		it('should work with a basic example', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'get',
@@ -112,17 +111,17 @@ describe('#addMethodREST', function () {
 				expects: 200
 			});
 
-			app.get('/' + name, function(req, res) {
+			app.get('/' + name, function (req, res) {
 				res.status(200).send('ok');
 			});
 
-			threadneedle[name]().done(function(result) {
+			threadneedle[name]().done(function (result) {
 				assert.equal(result.body, 'ok');
 				done();
 			});
 		});
 
-		it('should substitute to the url with a basic example', function(done) {
+		it('should substitute to the url with a basic example', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'get',
@@ -130,20 +129,20 @@ describe('#addMethodREST', function () {
 				expects: 200
 			});
 
-			app.get('/' + name, function(req, res) {
+			app.get('/' + name, function (req, res) {
 				res.status(200).send(req.query.key);
 			});
 
 			threadneedle[name]({
 				apiKey: '123'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.equal(result.body, '123');
 				done();
 			});
 		});
 
 
-		it('should substitute to the data', function(done) {
+		it('should substitute to the data', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -155,7 +154,7 @@ describe('#addMethodREST', function () {
 				expects: 200
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					query: req.query,
 					body: req.body
@@ -166,7 +165,7 @@ describe('#addMethodREST', function () {
 				apiKey: '123',
 				name: 'Chris',
 				age: 25
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.deepEqual(result.body.query, {
 					key: '123'
 				});
@@ -178,7 +177,7 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('should substitute to the headers', function(done) {
+		it('should substitute to the headers', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -191,19 +190,19 @@ describe('#addMethodREST', function () {
 				expects: 200
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.headers);
 			});
 
 			threadneedle[name]({
 				apiKey: '123'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.equal(result.body.authorization, 'Basic 123');
 				done();
 			});
 		});
 
-		it('should substitute to the auth', function(done) {
+		it('should substitute to the auth', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -215,20 +214,20 @@ describe('#addMethodREST', function () {
 				expects: 200
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.headers);
 			});
 
 			threadneedle[name]({
 				username: 'chris',
 				password: 'hello'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.equal(result.body.authorization, 'Basic Y2hyaXM6aGVsbG8=');
 				done();
 			});
 		});
 
-		it('should reject on invalid status code', function(done) {
+		it('should reject on invalid status code', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -236,35 +235,35 @@ describe('#addMethodREST', function () {
 				expects: 201
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.headers);
 			});
 
-			threadneedle[name]().done(function(result) {}, function(result) {
+			threadneedle[name]().done(function (result) {}, function (result) {
 				assert.equal(result.body.message, 'Invalid response status code');
 				done();
 			});
 		});
 
-		it('should reject on invalid status codes', function(done) {
+		it('should reject on invalid status codes', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				expects: [202, 201]
+				expects: [ 202, 201 ]
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.headers);
 			});
 
-			threadneedle[name]().done(function(result) {}, function(result) {
+			threadneedle[name]().done(function (result) {}, function (result) {
 				assert.equal(result.body.message, 'Invalid response status code');
 				done();
 			});
 		});
 
-		it('should reject on invalid body', function(done) {
+		it('should reject on invalid body', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -272,19 +271,19 @@ describe('#addMethodREST', function () {
 				expects: 'success'
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					failure: true
 				});
 			});
 
-			threadneedle[name]().done(function(result) {}, function(result) {
+			threadneedle[name]().done(function (result) {}, function (result) {
 				assert.equal(result.body.message, 'Invalid response body');
 				done();
 			});
 		});
 
-		it('should be ok when notExpect status code is fine', function(done) {
+		it('should be ok when notExpect status code is fine', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -292,13 +291,13 @@ describe('#addMethodREST', function () {
 				notExpects: 201
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					result: true
 				});
 			});
 
-			threadneedle[name]().done(function(result) {
+			threadneedle[name]().done(function (result) {
 				assert.deepEqual(result.body, {
 					result: true
 				});
@@ -306,7 +305,7 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('should reject when notExpect status code is bad', function(done) {
+		it('should reject when notExpect status code is bad', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -314,19 +313,19 @@ describe('#addMethodREST', function () {
 				notExpects: 200
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					result: true
 				});
 			});
 
-			threadneedle[name]().done(function() {}, function(result) {
+			threadneedle[name]().done(function () {}, function (result) {
 				assert.equal(result.body.message, 'Invalid response status code');
 				done();
 			});
 		});
 
-		it('should be ok when notExpect body is fine', function(done) {
+		it('should be ok when notExpect body is fine', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -334,13 +333,13 @@ describe('#addMethodREST', function () {
 				notExpects: 'success'
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					result: true
 				});
 			});
 
-			threadneedle[name]().done(function(result) {
+			threadneedle[name]().done(function (result) {
 				assert.deepEqual(result.body, {
 					result: true
 				});
@@ -348,7 +347,7 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('should reject when notExpect body is bad', function(done) {
+		it('should reject when notExpect body is bad', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
@@ -356,41 +355,41 @@ describe('#addMethodREST', function () {
 				notExpects: 'result'
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					result: true
 				});
 			});
 
-			threadneedle[name]().done(function() {}, function(result) {
+			threadneedle[name]().done(function () {}, function (result) {
 				assert.equal(result.body.message, 'Invalid response body');
 				done();
 			});
 		});
 
 
-		it('should run `before` on the params synchronously', function(done) {
+		it('should run `before` on the params synchronously', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				before: function(params) {
+				before: function (params) {
 					params.name = params.firstName + ' ' + params.lastName;
 					return params;
 				},
-				data: function(params) {
+				data: function (params) {
 					return params;
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.body);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris',
 				lastName: 'Houghton'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.deepEqual(result.body, {
 					firstName: 'Chris',
 					lastName: 'Houghton',
@@ -400,30 +399,30 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('should run `before` on the params asynchronously', function(done) {
+		it('should run `before` on the params asynchronously', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				before: function(params) {
-					return when.promise(function(resolve) {
+				before: function (params) {
+					return when.promise(function (resolve) {
 						params.name = params.firstName + ' ' + params.lastName;
 						resolve(params);
 					});
 				},
-				data: function(params) {
+				data: function (params) {
 					return params;
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.body);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris',
 				lastName: 'Houghton'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.deepEqual(result.body, {
 					firstName: 'Chris',
 					lastName: 'Houghton',
@@ -434,12 +433,12 @@ describe('#addMethodREST', function () {
 		});
 
 
-		it('should run `afterSuccess` on the params synchronously', function(done) {
+		it('should run `afterSuccess` on the params synchronously', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				afterSuccess: function(body) {
+				afterSuccess: function (body) {
 					delete body.firstName;
 					body.age = 25;
 				},
@@ -448,13 +447,13 @@ describe('#addMethodREST', function () {
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.body);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.deepEqual(result.body, {
 					age: 25
 				});
@@ -462,13 +461,13 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('should run `afterSuccess` on the params asynchronously', function(done) {
+		it('should run `afterSuccess` on the params asynchronously', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				afterSuccess: function(body) {
-					return when.promise(function(resolve) {
+				afterSuccess: function (body) {
+					return when.promise(function (resolve) {
 						body.age = 25;
 						resolve();
 					});
@@ -478,13 +477,13 @@ describe('#addMethodREST', function () {
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.body);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.deepEqual(result.body, {
 					firstName: 'Chris',
 					age: 25
@@ -493,12 +492,12 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('Should override with returned value in `afterSuccess`', function(done) {
+		it('Should override with returned value in `afterSuccess`', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				afterSuccess: function(body) {
+				afterSuccess: function (body) {
 					return {
 						data: body
 					};
@@ -508,27 +507,29 @@ describe('#addMethodREST', function () {
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json([req.body]);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function(result) {
-				assert.deepEqual(result.body.data, [{
-					firstName: 'Chris'
-				}]);
+			}).done(function (result) {
+				assert.deepEqual(result.body.data, [
+					{
+						firstName: 'Chris'
+					}
+				]);
 				done();
 			});
 		});
 
 
-		it('should run `afterFailure` on the params synchronously', function(done) {
+		it('should run `afterFailure` on the params synchronously', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				afterFailure: function(body) {
+				afterFailure: function (body) {
 					body.code = 'oauth_refresh';
 					return body;
 				},
@@ -538,13 +539,13 @@ describe('#addMethodREST', function () {
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.body);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function() {}, function(result) {
+			}).done(function () {}, function (result) {
 				assert.deepEqual(result.body, {
 					message: 'Invalid response status code',
 					response: {
@@ -562,12 +563,12 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('should run `afterFailure` on the params asynchronously', function(done) {
+		it('should run `afterFailure` on the params asynchronously', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				afterFailure: function(body) {
+				afterFailure: function (body) {
 					body.code = 'oauth_refresh';
 					return when(body);
 				},
@@ -577,13 +578,13 @@ describe('#addMethodREST', function () {
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.body);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function() {}, function(result) {
+			}).done(function () {}, function (result) {
 				assert.deepEqual(result.body, {
 					message: 'Invalid response status code',
 					response: {
@@ -601,13 +602,13 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('Should override with returned value in `afterFailure`', function(done) {
+		it('Should override with returned value in `afterFailure`', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
 				expects: 201,
-				afterFailure: function(body) {
+				afterFailure: function (body) {
 					return {
 						meh: 'no error here'
 					};
@@ -617,25 +618,25 @@ describe('#addMethodREST', function () {
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json([req.body]);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function() {}, function(result) {
+			}).done(function () {}, function (result) {
 				assert.equal(result.body.meh, 'no error here');
 				done();
 			});
 		});
 
 
-		it('should run `afterHeaders` on the params synchronously', function(done) {
+		it('should run `afterHeaders` on the params synchronously', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				afterHeaders: function(error, params, body, res) {
+				afterHeaders: function (error, params, body, res) {
 					return {
 						metaData: 'ABC'
 					};
@@ -645,13 +646,13 @@ describe('#addMethodREST', function () {
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.body);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.deepEqual(result.headers, {
 					metaData: 'ABC'
 				});
@@ -659,13 +660,13 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		it('should run `afterHeaders` on the params asynchronously', function(done) {
+		it('should run `afterHeaders` on the params asynchronously', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'post',
 				url: host + '/' + name,
-				afterHeaders: function(error, params, body, res) {
-					return when.promise(function(resolve) {
+				afterHeaders: function (error, params, body, res) {
+					return when.promise(function (resolve) {
 						resolve({
 							metaData: 'XYZ'
 						});
@@ -676,13 +677,13 @@ describe('#addMethodREST', function () {
 				}
 			});
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json(req.body);
 			});
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function(result) {
+			}).done(function (result) {
 				assert.deepEqual(result.headers, {
 					metaData: 'XYZ'
 				});
@@ -690,22 +691,22 @@ describe('#addMethodREST', function () {
 			});
 		});
 
-		function afterHeaderTestModel(name) {
+		function afterHeaderTestModel (name) {
 			return {
 				method: 'post',
 				url: host + '/' + name,
 				expects: 200,
-				afterSuccess: function(body, params, res) {
+				afterSuccess: function (body, params, res) {
 					if (params.asFlag) {
 						throw new Error('afterSuccess Error');
 					}
 				},
-				afterFailure: function(body, params, res) {
+				afterFailure: function (body, params, res) {
 					if (params.afFlag) {
 						throw new Error('afterFailure Error');
 					}
 				},
-				afterHeaders: function(error, params, body, res) {
+				afterHeaders: function (error, params, body, res) {
 					if (params.ahFlag) {
 						throw new Error('afterHeaders Error');
 					} else {
@@ -715,41 +716,41 @@ describe('#addMethodREST', function () {
 					}
 				}
 			};
-		};
+		}
 
-		it('Should place `afterHeaders` object in header after afterSuccess resolve', function(done) {
+		it('Should place `afterHeaders` object in header after afterSuccess resolve', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, afterHeaderTestModel(name));
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					success: true
 				});
 			});
 
 			threadneedle[name]({
-					asFlag: false,
-					afFlag: false,
-					ahFlag: false
-				})
-				.done(
-					function(result) {
-						assert.deepEqual(result.headers.gotError, false);
-						assert.deepEqual(result.body.success, true);
-						done();
-					},
-					function(result) {
-						assert.fail('Wrong clause - failing');
-						done();
-					}
-				);
+				asFlag: false,
+				afFlag: false,
+				ahFlag: false
+			})
+			.done(
+				function (result) {
+					assert.deepEqual(result.headers.gotError, false);
+					assert.deepEqual(result.body.success, true);
+					done();
+				},
+				function (result) {
+					assert.fail('Wrong clause - failing');
+					done();
+				}
+			);
 		});
 
-		it('Should place `afterHeaders` error in body after afterSuccess resolve', function(done) {
+		it('Should place `afterHeaders` error in body after afterSuccess resolve', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, afterHeaderTestModel(name));
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					success: true
 				});
@@ -761,11 +762,11 @@ describe('#addMethodREST', function () {
 				ahFlag: true
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers, {});
 					assert.deepEqual(result.body.message, 'afterHeaders Error');
 					done();
@@ -773,11 +774,11 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` object in header after afterSuccess reject', function(done) {
+		it('Should place `afterHeaders` object in header after afterSuccess reject', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, afterHeaderTestModel(name));
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					success: true
 				});
@@ -789,11 +790,11 @@ describe('#addMethodREST', function () {
 				ahFlag: false
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers.gotError, true);
 					assert.deepEqual(result.body.message, 'afterSuccess Error');
 					done();
@@ -801,11 +802,11 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` error in body after afterSuccess reject', function(done) {
+		it('Should place `afterHeaders` error in body after afterSuccess reject', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, afterHeaderTestModel(name));
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(200).json({
 					success: true
 				});
@@ -817,11 +818,11 @@ describe('#addMethodREST', function () {
 				ahFlag: true
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers, {});
 					assert.deepEqual(result.body.message, 'afterHeaders Error');
 					done();
@@ -829,11 +830,11 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` object in header after afterFailure resolve', function(done) {
+		it('Should place `afterHeaders` object in header after afterFailure resolve', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, afterHeaderTestModel(name));
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(400).json({
 					success: false
 				});
@@ -845,11 +846,11 @@ describe('#addMethodREST', function () {
 				ahFlag: false
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers.gotError, true);
 					assert.deepEqual(result.body.response.body.success, false);
 					done();
@@ -857,11 +858,11 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` error in body after afterFailure resolve', function(done) {
+		it('Should place `afterHeaders` error in body after afterFailure resolve', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, afterHeaderTestModel(name));
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(400).json({
 					success: false
 				});
@@ -873,11 +874,11 @@ describe('#addMethodREST', function () {
 				ahFlag: true
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers, {});
 					assert.deepEqual(result.body.message, 'afterHeaders Error');
 					done();
@@ -885,11 +886,11 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` object in header after afterFailure reject', function(done) {
+		it('Should place `afterHeaders` object in header after afterFailure reject', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, afterHeaderTestModel(name));
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(400).json({
 					success: false
 				});
@@ -901,11 +902,11 @@ describe('#addMethodREST', function () {
 				ahFlag: false
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers.gotError, true);
 					assert.deepEqual(result.body.message, 'afterFailure Error');
 					done();
@@ -913,11 +914,11 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` error in body after afterFailure reject', function(done) {
+		it('Should place `afterHeaders` error in body after afterFailure reject', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, afterHeaderTestModel(name));
 
-			app.post('/' + name, function(req, res) {
+			app.post('/' + name, function (req, res) {
 				res.status(400).json({
 					success: false
 				});
@@ -929,11 +930,11 @@ describe('#addMethodREST', function () {
 				ahFlag: true
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers, {});
 					assert.deepEqual(result.body.message, 'afterHeaders Error');
 					done();
@@ -942,7 +943,7 @@ describe('#addMethodREST', function () {
 		});
 
 
-		it('should add a {{temp_file}} parameter when `fileHandler` is true', function(done) {
+		it('should add a {{temp_file}} parameter when `fileHandler` is true', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, {
 				method: 'get',
@@ -952,19 +953,19 @@ describe('#addMethodREST', function () {
 					firstName: '{{firstName}}'
 				},
 				options: {
-					output: function(input) {
+					output: function (input) {
 						// should be available pre substituations
 						assert(input.temp_file);
 					}
 				},
-				afterSuccess: function(body, params) {
+				afterSuccess: function (body, params) {
 					assert(params.temp_file);
 					assert.equal(params.temp_file.indexOf('/tmp/'), 0);
 					assert.equal(params.temp_file.length, 41);
 				}
 			});
 
-			app.get('/' + name, function(req, res) {
+			app.get('/' + name, function (req, res) {
 				var filePath = __dirname + '/sample-file.png';
 				var stat = fs.statSync(filePath);
 				res.writeHead(200, {
@@ -977,39 +978,39 @@ describe('#addMethodREST', function () {
 
 			threadneedle[name]({
 				firstName: 'Chris'
-			}).done(function(body) {
+			}).done(function (body) {
 				done();
-			})
+			});
 		});
 
 
 	});
 
 
-	describe('Ad-hoc', function() {
+	describe('Ad-hoc', function () {
 
 		var threadneedle;
-		beforeEach(function() {
+		beforeEach(function () {
 			threadneedle = new ThreadNeedle();
 		});
 
-		it('should be fine with allowing the method config to be a function', function(done) {
+		it('should be fine with allowing the method config to be a function', function (done) {
 
 			var called = false;
 
-			threadneedle.addMethod('myCustomMethod', function(params) {
+			threadneedle.addMethod('myCustomMethod', function (params) {
 
 				assert(_.isObject(params));
 
 				var self = this;
 
-				return when.promise(function(resolve, reject) {
+				return when.promise(function (resolve, reject) {
 
 					assert.equal(params.name, 'Chris');
 					assert.deepEqual(self, threadneedle); // context
 					called = true;
 
-					setTimeout(function() {
+					setTimeout(function () {
 						resolve();
 					}, 200);
 
@@ -1018,10 +1019,10 @@ describe('#addMethodREST', function () {
 
 			threadneedle.myCustomMethod({
 				name: 'Chris'
-			}).done(function() {
+			}).done(function () {
 				assert(called);
 				done();
-			}, function(err) {
+			}, function (err) {
 				console.log(err);
 			});
 
@@ -1033,7 +1034,7 @@ describe('#addMethodREST', function () {
 				when.resolve({ success: true }) :
 				when.reject(new Error('functionModel Error'))
 			);
-		};
+		}
 
 		function afterHeadersFunction (error, params, body, res) {
 			if (params.ahFlag) {
@@ -1045,7 +1046,7 @@ describe('#addMethodREST', function () {
 			}
 		}
 
-		it('Should place `afterHeaders` object in header if function model resolve', function(done) {
+		it('Should place `afterHeaders` object in header if function model resolve', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, functionModel, afterHeadersFunction);
 
@@ -1054,12 +1055,12 @@ describe('#addMethodREST', function () {
 				ahFlag: true
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers.gotError, false);
 					assert.deepEqual(result.body.success, true);
 					done();
 				},
-				function(error) {
+				function (error) {
 					assert.fail('Wrong clause - failing');
 					assert.fail(error);
 					done();
@@ -1067,7 +1068,7 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` error in body if function model resolve', function(done) {
+		it('Should place `afterHeaders` error in body if function model resolve', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, functionModel, afterHeadersFunction);
 
@@ -1076,12 +1077,12 @@ describe('#addMethodREST', function () {
 				ahFlag: false
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					assert.fail(result);
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers, {});
 					assert.deepEqual(result.body.message, 'afterHeaders Error');
 					done();
@@ -1089,7 +1090,7 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` object in header if function model reject', function(done) {
+		it('Should place `afterHeaders` object in header if function model reject', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, functionModel, afterHeadersFunction);
 
@@ -1098,12 +1099,12 @@ describe('#addMethodREST', function () {
 				ahFlag: true
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					assert.fail(result);
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers.gotError, true);
 					assert.deepEqual(result.body.message, 'functionModel Error');
 					done();
@@ -1111,7 +1112,7 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should place `afterHeaders` error in body if function model reject', function(done) {
+		it('Should place `afterHeaders` error in body if function model reject', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, functionModel, afterHeadersFunction);
 
@@ -1120,12 +1121,12 @@ describe('#addMethodREST', function () {
 				ahFlag: false
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					assert.fail(result);
 					done();
 				},
-				function(result) {
+				function (result) {
 					assert.deepEqual(result.headers, {});
 					assert.deepEqual(result.body.message, 'afterHeaders Error');
 					done();
@@ -1133,7 +1134,7 @@ describe('#addMethodREST', function () {
 			);
 		});
 
-		it('Should throw error if `afterHeaders` is not a function', function(done) {
+		it('Should throw error if `afterHeaders` is not a function', function (done) {
 			var name = randString(10);
 			threadneedle.addMethod(name, functionModel, {});
 
@@ -1142,11 +1143,11 @@ describe('#addMethodREST', function () {
 				ahFlag: true
 			})
 			.done(
-				function(result) {
+				function (result) {
 					assert.fail(result);
 					done();
 				},
-				function(ahError) {
+				function (ahError) {
 					assert.strictEqual(ahError.message, 'afterHeaders must be a function.');
 					done();
 				}

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -11,17 +11,30 @@ const ThreadNeedle = require('../');
 
 const SOAPServer = require('./soapServer');
 
-describe.only('#addMethodSOAP', function () {
+function promiseFailFunc (done) {
+	return function (err) {
+		//eslint-disable-next-line no-console
+		console.log(err);
+		assert.fail(err);
+		done(err);
+	};
+}
 
-	const REGONLINE_TOKEN = require('./dummycredentials.json').regonline;
+function asyncTest (message, testFunction) {
+	it(message, async () => {
+		try {
+			await testFunction();
+		} catch (testError) {
+			//eslint-disable-next-line no-console
+			console.log(testError);
+			throw testError;
+		}
+	});
+}
 
-	function promiseFailFunc (done) {
-		return function (err) {
-			console.log(err);
-			assert.fail(err);
-			done();
-		};
-	}
+const REGONLINE_TOKEN = 'abc1234';
+
+describe('#addMethodSOAP', function () {
 
 	let soapServer;
 	before((done) => {
@@ -35,7 +48,7 @@ describe.only('#addMethodSOAP', function () {
 		});
 	});
 
-	describe.only('Running', function () {
+	describe('Running', function () {
 		this.timeout(30000);
 		let threadneedle;
 
@@ -45,8 +58,7 @@ describe.only('#addMethodSOAP', function () {
 
 				type: 'SOAP',
 
-				// wsdl: 'https://www.regonline.com/api/default.asmx?WSDL',
-				wsdl: 'https://localhost:8000/default.asmx?WSDL',
+				wsdl: 'http://localhost:8000/default.asmx?WSDL',
 
 				options: {
 					headers: [
@@ -125,10 +137,10 @@ describe.only('#addMethodSOAP', function () {
 		});
 
 
-		it.only('should be able to add a standard SOAP method', function (done) {
+		it('should be able to add a standard SOAP method', function (done) {
 
 			when(threadneedle.addMethod(
-				'list_events',
+				'list_events_test',
 				{
 					method: 'GetEvents',
 
@@ -140,7 +152,7 @@ describe.only('#addMethodSOAP', function () {
 
 			.then(
 				function () {
-					assert(_.isFunction(threadneedle['list_events']));
+					assert(_.isFunction(threadneedle['list_events_test']));
 					done();
 				},
 				promiseFailFunc(done)
@@ -148,17 +160,23 @@ describe.only('#addMethodSOAP', function () {
 
 		});
 
-		it('should be able to execute a standard SOAP method', function (done) {
+		asyncTest('should be able to execute a standard SOAP method', async function () {
 
+			await threadneedle.addMethod(
+				'list_events',
+				{
+					method: 'GetEvents',
 
-			when(threadneedle['list_events']({}))
+					data: {
+						orderBy: 'ID DESC',
+					}
+				}
+			);
 
-			.then(function (results) {
-				assert.deepEqual(results.headers, {});
-				assert(results.body['GetEventsResult']['Success']);
-			})
+			const results = await threadneedle['list_events']({});
 
-			.then(done, promiseFailFunc(done));
+			assert.deepEqual(results.headers, {});
+			assert(results.body['GetEventsResult']['Success']);
 
 		});
 
@@ -205,7 +223,7 @@ describe.only('#addMethodSOAP', function () {
 
 				type: 'SOAP',
 
-				wsdl: 'https://www.regonline.com/api/default.asmx?WSDL',
+				wsdl: 'http://localhost:8000/default.asmx?WSDL',
 
 				options: {
 					headers: [
@@ -525,7 +543,7 @@ describe.only('#addMethodSOAP', function () {
 
 					type: 'SOAP',
 
-					wsdl: 'https://www.regonline.com/api/default.asmx?WSDL',
+					wsdl: 'http://localhost:8000/default.asmx?WSDL',
 
 					options: {
 						headers: [

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -1,16 +1,18 @@
-var assert       = require('assert');
-var _            = require('lodash');
-var when            = require('when');
-var express      = require('express');
-var fs           = require('fs');
-var randString   = require('mout/random/randString');
-var globalize    = require('../lib/addMethod/globalize');
-var ThreadNeedle = require('../');
+const assert = require('assert');
+const fs = require('fs');
+
+const _ = require('lodash');
+const when = require('when');
+const express = require('express');
+
+const randString = require('mout/random/randString');
+const globalize = require('../lib/addMethod/globalize');
+const ThreadNeedle = require('../');
 
 
-describe('#addMethodSOAP', function () {
+describe.only('#addMethodSOAP', function () {
 
-	var regonline_token = require('./dummycredentials.json').regonline;
+	const REGONLINE_TOKEN = require('./dummycredentials.json').regonline;
 
 	function promiseFailFunc (done) {
 		return function (err) {
@@ -22,13 +24,13 @@ describe('#addMethodSOAP', function () {
 
 	describe('Running', function () {
 		this.timeout(30000);
-		var threadneedle;
+		let threadneedle;
 
 		before(function () {
-			threadneedle = new ThreadNeedle(true);
+			threadneedle = new ThreadNeedle();
 			threadneedle.global({
 
-				soap: true,
+				type: 'SOAP',
 
 				wsdl: 'https://www.regonline.com/api/default.asmx?WSDL',
 
@@ -37,7 +39,7 @@ describe('#addMethodSOAP', function () {
 						{
 							value: {
 								TokenHeader: {
-									APIToken: regonline_token
+									APIToken: REGONLINE_TOKEN
 								}
 							},
 							xmlns: 'http://www.regonline.com/api',
@@ -53,18 +55,18 @@ describe('#addMethodSOAP', function () {
 
 		it('should error if wsdl is not provided (or not a string)', function (done) {
 
-			var privateThreadneedle = new ThreadNeedle(true);
+			const privateThreadneedle = new ThreadNeedle();
 
 			privateThreadneedle.global({
 
-				soap: true,
+				type: 'SOAP',
 
 				options: {
 					headers: [
 						{
 							value: {
 								TokenHeader: {
-									APIToken: regonline_token
+									APIToken: REGONLINE_TOKEN
 								}
 							},
 							xmlns: 'http://www.regonline.com/api',
@@ -88,12 +90,12 @@ describe('#addMethodSOAP', function () {
 				}
 			))
 
-			.done(
+			.then(
 				function () {
 
 					when(privateThreadneedle['list_events']({}))
 
-					.done(
+					.then(
 						promiseFailFunc(done),
 						function (err) {
 							assert.strictEqual(err, '`wsdl` field (string) must be provided to create a client instance.');
@@ -121,7 +123,7 @@ describe('#addMethodSOAP', function () {
 				}
 			))
 
-			.done(
+			.then(
 				function () {
 					assert(_.isFunction(threadneedle['list_events']));
 					done();
@@ -141,7 +143,7 @@ describe('#addMethodSOAP', function () {
 				assert(results.body['GetEventsResult']['Success']);
 			})
 
-			.done(done, promiseFailFunc(done));
+			.then(done, promiseFailFunc(done));
 
 		});
 
@@ -159,7 +161,7 @@ describe('#addMethodSOAP', function () {
 				}
 			))
 
-			.done(
+			.then(
 				function (result) {
 
 					when(threadneedle['list_events2']({
@@ -171,7 +173,7 @@ describe('#addMethodSOAP', function () {
 						assert(results.body['GetEventsResult']['Success']);
 					})
 
-					.done(done, promiseFailFunc(done));
+					.then(done, promiseFailFunc(done));
 
 				},
 				promiseFailFunc(done)
@@ -182,11 +184,11 @@ describe('#addMethodSOAP', function () {
 
 		it('should substitute to the options with a basic example', function (done) {
 
-			var privateThreadneedle = new ThreadNeedle(true);
+			const privateThreadneedle = new ThreadNeedle();
 
 			privateThreadneedle.global({
 
-				soap: true,
+				type: 'SOAP',
 
 				wsdl: 'https://www.regonline.com/api/default.asmx?WSDL',
 
@@ -219,11 +221,11 @@ describe('#addMethodSOAP', function () {
 				}
 			))
 
-			.done(
+			.then(
 				function () {
 
 					when(privateThreadneedle['list_events']({
-						access_token: regonline_token
+						access_token: REGONLINE_TOKEN
 					}))
 
 					.then(function (results) {
@@ -231,7 +233,7 @@ describe('#addMethodSOAP', function () {
 						assert(results.body['GetEventsResult']['Success']);
 					})
 
-					.done(done, promiseFailFunc(done));
+					.then(done, promiseFailFunc(done));
 
 				},
 				promiseFailFunc(done)
@@ -260,12 +262,12 @@ describe('#addMethodSOAP', function () {
 				}
 			))
 
-			.done(
+			.then(
 				function (result) {
 
 					when(threadneedle['list_events3']({}))
 
-					.done(
+					.then(
 						promiseFailFunc(done),
 						function (err) {
 							assert.deepEqual(err.headers, {});
@@ -299,12 +301,12 @@ describe('#addMethodSOAP', function () {
 				}
 			))
 
-			.done(
+			.then(
 				function (result) {
 
 					when(threadneedle['list_events4']({}))
 
-					.done(
+					.then(
 						promiseFailFunc(done),
 						function (err) {
 							assert(err.body.message === 'Test Error');
@@ -325,7 +327,8 @@ describe('#addMethodSOAP', function () {
 
 		it('should be fine with allowing the method config to be a function', function (done) {
 
-			var threadneedle = new ThreadNeedle(true);
+			const threadneedle = new ThreadNeedle();
+			threadneedle.global({ type: 'soap' });
 
 			threadneedle.addMethod(
 				'myCustomMethod',
@@ -336,7 +339,7 @@ describe('#addMethodSOAP', function () {
 
 			threadneedle.myCustomMethod({ name: 'Chris' })
 
-			.done(
+			.then(
 				function (val) {
 					assert.deepEqual(val.body, 'Chris');
 					done();
@@ -367,15 +370,16 @@ describe('#addMethodSOAP', function () {
 		}
 
 		it('Should place `afterHeaders` object in header if function model resolve', function (done) {
-			var name = randString(10);
-			var threadneedle = new ThreadNeedle(true);
+			const name = randString(10);
+			const threadneedle = new ThreadNeedle();
+			threadneedle.global({ type: 'soap' });
 			threadneedle.addMethod(name, functionModel, afterHeadersFunction);
 
 			threadneedle[name]({
 				passFlag: true,
 				ahFlag: true
 			})
-			.done(
+			.then(
 				function (result) {
 					assert.deepEqual(result.headers.gotError, false);
 					assert.deepEqual(result.body.success, true);
@@ -390,15 +394,16 @@ describe('#addMethodSOAP', function () {
 		});
 
 		it('Should place `afterHeaders` error in body if function model resolve', function (done) {
-			var name = randString(10);
-			var threadneedle = new ThreadNeedle(true);
+			const name = randString(10);
+			const threadneedle = new ThreadNeedle();
+			threadneedle.global({ type: 'soap' });
 			threadneedle.addMethod(name, functionModel, afterHeadersFunction);
 
 			threadneedle[name]({
 				passFlag: true,
 				ahFlag: false
 			})
-			.done(
+			.then(
 				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					assert.fail(result);
@@ -413,15 +418,16 @@ describe('#addMethodSOAP', function () {
 		});
 
 		it('Should place `afterHeaders` object in header if function model reject', function (done) {
-			var name = randString(10);
-			var threadneedle = new ThreadNeedle(true);
+			const name = randString(10);
+			const threadneedle = new ThreadNeedle();
+			threadneedle.global({ type: 'soap' });
 			threadneedle.addMethod(name, functionModel, afterHeadersFunction);
 
 			threadneedle[name]({
 				passFlag: false,
 				ahFlag: true
 			})
-			.done(
+			.then(
 				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					assert.fail(result);
@@ -436,15 +442,16 @@ describe('#addMethodSOAP', function () {
 		});
 
 		it('Should place `afterHeaders` error in body if function model reject', function (done) {
-			var name = randString(10);
-			var threadneedle = new ThreadNeedle(true);
+			const name = randString(10);
+			const threadneedle = new ThreadNeedle();
+			threadneedle.global({ type: 'soap' });
 			threadneedle.addMethod(name, functionModel, afterHeadersFunction);
 
 			threadneedle[name]({
 				passFlag: false,
 				ahFlag: false
 			})
-			.done(
+			.then(
 				function (result) {
 					assert.fail('Wrong clause - succeeding');
 					assert.fail(result);
@@ -459,15 +466,16 @@ describe('#addMethodSOAP', function () {
 		});
 
 		it('Should throw error if `afterHeaders` is not a function', function (done) {
-			var name = randString(10);
-			var threadneedle = new ThreadNeedle(true);
+			const name = randString(10);
+			const threadneedle = new ThreadNeedle();
+			threadneedle.global({ type: 'soap' });
 			threadneedle.addMethod(name, functionModel, {});
 
 			threadneedle[name]({
 				passFlag: true,
 				ahFlag: true
 			})
-			.done(
+			.then(
 				function (result) {
 					assert.fail(result);
 					done();
@@ -487,7 +495,7 @@ describe('#addMethodSOAP', function () {
 
 		it('should be fine with allowing a single SOAP method config from REST mode', function (done) {
 
-			var threadneedle = new ThreadNeedle();
+			const threadneedle = new ThreadNeedle();
 
 			threadneedle.addMethod(
 				'myCustomMethod',
@@ -500,7 +508,7 @@ describe('#addMethodSOAP', function () {
 				'mySOAPMethod',
 				{
 
-					soap: true,
+					type: 'SOAP',
 
 					wsdl: 'https://www.regonline.com/api/default.asmx?WSDL',
 
@@ -509,7 +517,7 @@ describe('#addMethodSOAP', function () {
 							{
 								value: {
 									TokenHeader: {
-										APIToken: regonline_token
+										APIToken: REGONLINE_TOKEN
 									}
 								},
 								xmlns: 'http://www.regonline.com/api',
@@ -534,7 +542,7 @@ describe('#addMethodSOAP', function () {
 
 			threadneedle['mySOAPMethod']({})
 
-			.done(
+			.then(
 				function (val) {
 					assert.deepEqual(val.headers.success, true);
 					assert(val.body['GetEventsResult']['Success']);

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -180,6 +180,54 @@ describe('#addMethodSOAP', function () {
 
 		});
 
+		asyncTest('should prepend baseMethod to model method', async function () {
+
+			const privateThreadneedle = new ThreadNeedle();
+
+			privateThreadneedle.global({
+
+				type: 'SOAP',
+
+				baseMethod: 'Get',
+
+				wsdl: 'http://localhost:8000/default.asmx?WSDL',
+
+				options: {
+					headers: [
+						{
+							value: {
+								TokenHeader: {
+									APIToken: REGONLINE_TOKEN
+								}
+							},
+							xmlns: 'http://www.regonline.com/api',
+						}
+					]
+				},
+
+				data: {}
+
+
+			});
+
+			await privateThreadneedle.addMethod(
+				'list_events',
+				{
+					method: 'Events',
+
+					data: {
+						orderBy: 'ID DESC',
+					}
+				}
+			);
+
+			const results = await threadneedle['list_events']({});
+
+			assert.deepEqual(results.headers, {});
+			assert(results.body['GetEventsResult']['Success']);
+
+
+		});
 
 		it('should substitute to the url and data with a basic example', function (done) {
 

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -9,6 +9,7 @@ const randString = require('mout/random/randString');
 const globalize = require('../lib/addMethod/globalize');
 const ThreadNeedle = require('../');
 
+const SOAPServer = require('./soapServer');
 
 describe.only('#addMethodSOAP', function () {
 

--- a/tests/addMethodSOAP_test.js
+++ b/tests/addMethodSOAP_test.js
@@ -23,7 +23,19 @@ describe.only('#addMethodSOAP', function () {
 		};
 	}
 
-	describe('Running', function () {
+	let soapServer;
+	before((done) => {
+		soapServer = new SOAPServer(8000);
+
+		soapServer.startServer((startError) => {
+			if (startError) {
+				throw startError;
+			}
+			done();
+		});
+	});
+
+	describe.only('Running', function () {
 		this.timeout(30000);
 		let threadneedle;
 
@@ -33,7 +45,8 @@ describe.only('#addMethodSOAP', function () {
 
 				type: 'SOAP',
 
-				wsdl: 'https://www.regonline.com/api/default.asmx?WSDL',
+				// wsdl: 'https://www.regonline.com/api/default.asmx?WSDL',
+				wsdl: 'https://localhost:8000/default.asmx?WSDL',
 
 				options: {
 					headers: [
@@ -52,6 +65,7 @@ describe.only('#addMethodSOAP', function () {
 
 
 			});
+
 		});
 
 		it('should error if wsdl is not provided (or not a string)', function (done) {
@@ -111,7 +125,7 @@ describe.only('#addMethodSOAP', function () {
 		});
 
 
-		it('should be able to add a standard SOAP method', function (done) {
+		it.only('should be able to add a standard SOAP method', function (done) {
 
 			when(threadneedle.addMethod(
 				'list_events',
@@ -556,6 +570,15 @@ describe.only('#addMethodSOAP', function () {
 
 		});
 
+	});
+
+	after((done) => {
+		soapServer.stopServer((closeError) => {
+			if (closeError) {
+				throw closeError;
+			}
+			done();
+		});
 	});
 
 });

--- a/tests/global_test.js
+++ b/tests/global_test.js
@@ -4,7 +4,7 @@ const ThreadNeedle = require('../');
 
 describe('Global settings', function () {
 
-	describe.only('#global', function () {
+	describe('#global', function () {
 
 		it('type should be `rest` by default', function () {
 			const threadneedle = new ThreadNeedle();

--- a/tests/global_test.js
+++ b/tests/global_test.js
@@ -1,22 +1,40 @@
-var assert       = require('assert');
-var _            = require('lodash');
-var ThreadNeedle = require('../');
+const assert = require('assert');
+const _ = require('lodash');
+const ThreadNeedle = require('../');
 
 describe('Global settings', function () {
 
-  describe('#global', function () {
+	describe.only('#global', function () {
 
-    it('should set the global settings', function () {
-      var threadneedle = new ThreadNeedle();
-      threadneedle.global({
-        chris: 'test'
-      });
-      assert.deepEqual(threadneedle._globalOptions, { 
-        chris: 'test'
-      });
-    });
+		it('type should be `rest` by default', function () {
+			const threadneedle = new ThreadNeedle();
+			assert.deepEqual(threadneedle._globalOptions, {
+				type: 'rest'
+			});
+		});
 
-  });
+		it('should set the global settings', function () {
+			const threadneedle = new ThreadNeedle();
+			threadneedle.global({
+				chris: 'test'
+			});
+			assert.deepEqual(threadneedle._globalOptions, {
+				type: 'rest',
+				chris: 'test'
+			});
+		});
+
+		it('should override default if `type` is defined and valid', function () {
+			const threadneedle = new ThreadNeedle();
+			threadneedle.global({
+				type: 'SOAP'
+			});
+			assert.deepEqual(threadneedle._globalOptions, {
+				type: 'soap'
+			});
+		});
+
+	});
 
 
 });

--- a/tests/global_test.js
+++ b/tests/global_test.js
@@ -2,6 +2,8 @@ const assert = require('assert');
 const _ = require('lodash');
 const ThreadNeedle = require('../');
 
+const { handleDevFlagTest } = require('./testUtils.js');
+
 describe('Global settings', function () {
 
 	describe('#global', function () {
@@ -34,7 +36,17 @@ describe('Global settings', function () {
 			});
 		});
 
-	});
+		handleDevFlagTest('should error if soap flag is used in development mode', function () {
+			try {
+				const threadneedle = new ThreadNeedle(true);
+				assert.fail('Did not error for SOAP flag usage in dev mode.');
+			} catch (soapFlagError) {
+				assert(soapFlagError.message.includes('`soap` flag has been deprecated. Use `type: \'SOAP\'` instead.'));
+			}
+		});
 
+
+
+	});
 
 });

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -322,7 +322,7 @@ describe('#globalize', function () {
 	});
 
 
-	describe.only('validateObjectArgumentByReference', function () {
+	describe('validateObjectArgumentByReference', function () {
 
 		const originalObject = {
 			test: 'Hello world'

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -11,27 +11,7 @@ const referenceModificationErrorMessage = 'Modification by reference is deprecat
 const referenceValidator = validateObjectArgumentByReference(referenceModificationErrorMessage, nonObjectErrorMessage);
 
 const devMode = process.env.NODE_ENV === 'development';
-const handleDevFlagTest = (
-	devMode ?
-	it :
-	(testMessage, testFunction) => {
-		if (testFunction.length) { //Check whether the function expects any args
-			it(testMessage, (done) => {
-				process.env.NODE_ENV = 'development';
-				testFunction((...doneArgs) => {
-					delete process.env.NODE_ENV;
-					done(...doneArgs);
-				});
-			});
-		} else {
-			it(testMessage, () => {
-				process.env.NODE_ENV = 'development';
-				testFunction();
-				delete process.env.NODE_ENV;
-			});
-		}
-	}
-);
+const { handleDevFlagTest } = require('./testUtils.js');
 
 describe('#globalize', function () {
 

--- a/tests/soapServer/describe.json
+++ b/tests/soapServer/describe.json
@@ -1,0 +1,5236 @@
+{
+	"RegOnline_x0020_API": {
+		"RegOnline_x0020_APISoap": {
+			"CheckinRegistrationsForEvent": {
+				"input": {
+					"registrationIDs": "s:string"
+				},
+				"output": {
+					"CheckinRegistrationsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"CheckinRegistrationsForAgendaItem": {
+				"input": {
+					"registrationIDs": "s:string",
+					"agendaItemID": "s:int",
+					"eventID": "s:int"
+				},
+				"output": {
+					"CheckinRegistrationsForAgendaItemResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"UpdateRegistration": {
+				"input": {
+					"registration": {
+						"ID": "s:int",
+						"EventID": "s:int",
+						"GroupID": "s:int",
+						"RegTypeID": "s:int",
+						"RegistrationType": "s:string",
+						"RegTypeDescription": "s:string",
+						"StatusID": "s:int",
+						"StatusDescription": "s:string",
+						"Prefix": "s:string",
+						"FirstName": "s:string",
+						"MiddleName": "s:string",
+						"LastName": "s:string",
+						"Suffix": "s:string",
+						"Title": "s:string",
+						"Email": "s:string",
+						"Company": "s:string",
+						"Address1": "s:string",
+						"Address2": "s:string",
+						"Address3": "s:string",
+						"City": "s:string",
+						"State": "s:string",
+						"Country": "s:string",
+						"PostalCode": "s:string",
+						"BalanceDue": "s:decimal",
+						"Phone": "s:string",
+						"HomePhone": "s:string",
+						"Extension": "s:string",
+						"Fax": "s:string",
+						"CellPhone": "s:string",
+						"CCEmail": "s:string",
+						"BadgeName": "s:string",
+						"CustID": "s:string",
+						"Photo": "s:string",
+						"DateOfBirth": "s:dateTime",
+						"Gender": "s:string",
+						"NationalityID": "s:int",
+						"Nationality": "s:string",
+						"RoomSharerID": "s:int",
+						"MembershipID": "s:string",
+						"CheckedIn": "s:boolean",
+						"CancelDate": "s:dateTime",
+						"DirectoryOptOut": "s:boolean",
+						"IsSubstitute": "s:boolean",
+						"Notes": "s:string",
+						"AddBy": "s:string",
+						"AddDate": "s:dateTime",
+						"ModBy": "s:string",
+						"ModDate": "s:dateTime",
+						"PaymentDocNumber": "s:string",
+						"GoogleVariableValue": "s:string",
+						"APIToken": "s:string",
+						"SessionId": "s:string",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				},
+				"output": {
+					"UpdateRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomReportsForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomReportsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomReport[]": {
+								"ID": "s:int",
+								"Name": "s:string",
+								"EventID": "s:int",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomReports": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomReportsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomReport[]": {
+								"ID": "s:int",
+								"Name": "s:string",
+								"EventID": "s:int",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetDirectories": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int"
+				},
+				"output": {
+					"GetDirectoriesResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomReport[]": {
+								"ID": "s:int",
+								"Name": "s:string",
+								"EventID": "s:int",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetDirectory": {
+				"input": {
+					"directoryID": "s:int",
+					"eventID": "s:int",
+					"registrationID": "s:int"
+				},
+				"output": {
+					"GetDirectoryResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GetAttendeeMobileAppSettings": {
+				"input": {
+					"eventID": "s:int",
+					"accessCode": "s:string"
+				},
+				"output": {
+					"_GetAttendeeMobileAppSettingsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"eventtitle": "s:string",
+							"eventid": "s:int",
+							"customerid": "s:int",
+							"isnewuxevent": "s:boolean",
+							"eventaddress": "s:string",
+							"allowupdates": "s:boolean",
+							"allowpartialupdates": "s:boolean",
+							"url": "s:string",
+							"hidecontactinfo": "s:boolean",
+							"showyelp": "s:boolean",
+							"floormap": "s:string",
+							"errorcode": "s:int",
+							"statusmsg": "s:string",
+							"updateurl": "s:string",
+							"passwordurl": "s:string",
+							"locations": {
+								"location[]": {
+									"name": "s:string",
+									"type": "s:string",
+									"address": "s:string",
+									"icon": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"social": {
+								"twitter": {
+									"enabled": "s:boolean",
+									"hashtag": "s:string",
+									"widgetId": "s:string",
+									"defaulttweet": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"facebook": {
+									"enabled": "s:boolean",
+									"apikey": "s:string",
+									"pageid": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"linkedin": {
+									"enabled": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"style": {
+								"bgcolor": "s:string",
+								"textcolor": "s:string",
+								"linkcolor": "s:string",
+								"headerbgcolor": "s:string",
+								"headertextcolor": "s:string",
+								"headerhtml": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"culture": "s:string",
+							"resources": {
+								"resource[]": {
+									"key": "s:string",
+									"value": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"logging": "s:boolean",
+							"googlewebpropertyid": "s:string",
+							"googlevariableindex": "s:int",
+							"goolgevariablename": "s:string",
+							"showeucookieribbon": "s:boolean",
+							"isGuestLoginEnabledOnEvent": "s:boolean",
+							"isEventEligibleForGuest": "s:boolean",
+							"logoImageSrc": "s:string",
+							"logoLinkUrl": "s:string",
+							"isPasswordEnabledOnCustomer": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GetOrganizerMobileAppSettings": {
+				"input": {},
+				"output": {
+					"_GetOrganizerMobileAppSettingsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"resources": {
+								"setting[]": {
+									"key": "s:string",
+									"value": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"showeucookieribbon": "s:boolean",
+							"IsEnableLanyon": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"ValidateSFUser": {
+				"input": {
+					"userId": "s:string",
+					"token": "s:string"
+				},
+				"output": {
+					"ValidateSFUserResult": "s:int"
+				}
+			},
+			"UpdateEvent": {
+				"input": {
+					"updateEvent": {
+						"Id": "s:int",
+						"Title": "s:string",
+						"StartDate": "s:string",
+						"StartTime": "s:string",
+						"EndDate": "s:string",
+						"EndTime": "s:string",
+						"ClientEventId": "s:string",
+						"EventFee": "s:decimal",
+						"City": "s:string",
+						"State": "s:string",
+						"Country": "s:string",
+						"PostalCode": "s:string",
+						"LocationName": "s:string",
+						"LocationPhone": "s:string",
+						"LocationAddress1": "s:string",
+						"LocationAddress2": "s:string",
+						"ContactEmailAddress": "s:string",
+						"TimeZone": "s:string",
+						"Capacity": "s:int",
+						"CurrencyCode": "s:string",
+						"RegistrationTarget": "s:int",
+						"InternalNotes": "s:string",
+						"RegistrationFormUrl": "s:string",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				},
+				"output": {
+					"UpdateEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"ID": "s:int",
+							"CustomerID": "s:int",
+							"ParentID": "s:int",
+							"Status": "s:string",
+							"Title": "s:string",
+							"StartDate": "s:dateTime",
+							"EndDate": "s:dateTime",
+							"ActiveDate": "s:dateTime",
+							"ClientEventID": "s:string",
+							"TypeID": "s:int",
+							"Type": "s:string",
+							"City": "s:string",
+							"State": "s:string",
+							"Country": "s:string",
+							"CountryCode": "s:string",
+							"PostalCode": "s:string",
+							"LocationName": "s:string",
+							"LocationRoom": "s:string",
+							"LocationPhone": "s:string",
+							"LocationBuilding": "s:string",
+							"LocationAddress1": "s:string",
+							"LocationAddress2": "s:string",
+							"TimeZone": "s:string",
+							"Capacity": "s:int",
+							"CurrencyCode": "s:string",
+							"Keywords": "s:string",
+							"AddDate": "s:dateTime",
+							"AddBy": "s:string",
+							"ModDate": "s:dateTime",
+							"ModBy": "s:string",
+							"Channel": "s:string",
+							"IsWaitlisted": "s:boolean",
+							"Culture": "s:string",
+							"MediaType": "s:string",
+							"IsActive": "s:boolean",
+							"IsOnSite": "s:boolean",
+							"Latitude": "s:decimal",
+							"Longitude": "s:decimal",
+							"FloorMap": "s:string",
+							"InternalNotes": "s:string",
+							"TotalRevenue": "s:decimal",
+							"TotalRegistrations": "s:int",
+							"TotalCancels": "s:int",
+							"TotalSubstitutions": "s:int",
+							"TargetAttendance": "s:int",
+							"TotalIncompletes": "s:int",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsByEventID": {
+				"input": {
+					"eventID": "s:int",
+					"filter": "s:string"
+				},
+				"output": {
+					"GetRegistrationsByEventIDResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"Login": {
+				"input": {
+					"username": "s:string",
+					"password": "s:string"
+				},
+				"output": {
+					"LoginResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"Success": "s:boolean",
+							"OutMessage": "s:string",
+							"RedirectUrl": "s:string",
+							"EventSessionId": "s:string",
+							"CustomerId": "s:int",
+							"DisplayCaptcha": "s:boolean",
+							"IsCustomerDeactivated": "s:boolean",
+							"APIToken": "s:string",
+							"Email": "s:string",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"LoginRegistrantForPost": {
+				"input": {},
+				"output": {}
+			},
+			"LoginRegistrant": {
+				"input": {
+					"eventID": "s:int",
+					"email": "s:string",
+					"password": "s:string"
+				},
+				"output": {
+					"LoginRegistrantResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GuestLogin": {
+				"input": {
+					"eventID": "s:int",
+					"email": "s:string",
+					"password": "s:string",
+					"glpk": "s:string",
+					"rie": "s:string"
+				},
+				"output": {
+					"_GuestLoginResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GuestLoginForPost": {
+				"input": {},
+				"output": {}
+			},
+			"_VerifyGuestLogin": {
+				"input": {
+					"eventId": "s:int",
+					"email": "s:string",
+					"glpk": "s:string",
+					"rie": "s:string"
+				},
+				"output": {
+					"_VerifyGuestLoginResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"isGuestRegistration": "s:boolean",
+							"isVerificationEmailSent": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_VerifyGuestLoginForPost": {
+				"input": {},
+				"output": {}
+			},
+			"_VerifyPasswordRequiredToAccess": {
+				"input": {
+					"eventId": "s:int",
+					"email": "s:string",
+					"glpk": "s:string",
+					"rie": "s:string"
+				},
+				"output": {
+					"_VerifyPasswordRequiredToAccessResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"isGuestRegistration": "s:boolean",
+							"isPasswordEnabled": "s:boolean",
+							"isVerificationEmailSent": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_VerifyPasswordRequiredToAccessForPost": {
+				"input": {},
+				"output": {}
+			},
+			"CopyEvent": {
+				"input": {
+					"eventId": "s:int"
+				},
+				"output": {
+					"CopyEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"ID": "s:int",
+							"CustomerID": "s:int",
+							"ParentID": "s:int",
+							"Status": "s:string",
+							"Title": "s:string",
+							"StartDate": "s:dateTime",
+							"EndDate": "s:dateTime",
+							"ActiveDate": "s:dateTime",
+							"ClientEventID": "s:string",
+							"TypeID": "s:int",
+							"Type": "s:string",
+							"City": "s:string",
+							"State": "s:string",
+							"Country": "s:string",
+							"CountryCode": "s:string",
+							"PostalCode": "s:string",
+							"LocationName": "s:string",
+							"LocationRoom": "s:string",
+							"LocationPhone": "s:string",
+							"LocationBuilding": "s:string",
+							"LocationAddress1": "s:string",
+							"LocationAddress2": "s:string",
+							"TimeZone": "s:string",
+							"Capacity": "s:int",
+							"CurrencyCode": "s:string",
+							"Keywords": "s:string",
+							"AddDate": "s:dateTime",
+							"AddBy": "s:string",
+							"ModDate": "s:dateTime",
+							"ModBy": "s:string",
+							"Channel": "s:string",
+							"IsWaitlisted": "s:boolean",
+							"Culture": "s:string",
+							"MediaType": "s:string",
+							"IsActive": "s:boolean",
+							"IsOnSite": "s:boolean",
+							"Latitude": "s:decimal",
+							"Longitude": "s:decimal",
+							"FloorMap": "s:string",
+							"InternalNotes": "s:string",
+							"TotalRevenue": "s:decimal",
+							"TotalRegistrations": "s:int",
+							"TotalCancels": "s:int",
+							"TotalSubstitutions": "s:int",
+							"TargetAttendance": "s:int",
+							"TotalIncompletes": "s:int",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetEvents": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetEventsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetPublicEvents": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetPublicEventsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetEvent": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"GetEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GetEventForUser": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"_GetEventForUserResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetSurveysForEvent": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"GetSurveysForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetEventStatistics": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"GetEventStatisticsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetEventWebsite": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"GetEventWebsiteResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEventWebsite[]": {
+								"EventID": "s:int",
+								"AreTabsVisible": "s:boolean",
+								"IsRegisterNowButtonVisible": "s:boolean",
+								"IsContactDetailsSectionVisible": "s:boolean",
+								"IsSpacesRemainingVisible": "s:boolean",
+								"IsEarlyBirdAvailableVisible": "s:boolean",
+								"IsAddToCalendarLinkVisible": "s:boolean",
+								"IsTellAFriendLinkVisible": "s:boolean",
+								"IsFeaturesSectionVisible": "s:boolean",
+								"IsGlobalHeaderVisible": "s:boolean",
+								"IsGlobalFooterVisible": "s:boolean",
+								"IsWebsiteHeaderVisible": "s:boolean",
+								"IsWebsiteFooterVisible": "s:boolean",
+								"WebsiteHeader": "s:string",
+								"WebsiteFooter": "s:string",
+								"SummaryTab": {
+									"TabType": "EventWebsiteTabType|s:string|Summary,Lodging,Agenda,Directory,Custom,Speaker",
+									"Title": "s:string",
+									"IsVisible": "s:boolean",
+									"IsCustomContentVisible": "s:boolean",
+									"CustomContent": "s:string",
+									"IsEventDetailSectionVisible": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"LodgingTab": {
+									"TabType": "EventWebsiteTabType|s:string|Summary,Lodging,Agenda,Directory,Custom,Speaker",
+									"Title": "s:string",
+									"IsVisible": "s:boolean",
+									"IsCustomContentVisible": "s:boolean",
+									"CustomContent": "s:string",
+									"IsLodgingInformationVisible": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"AgendaTab": {
+									"TabType": "EventWebsiteTabType|s:string|Summary,Lodging,Agenda,Directory,Custom,Speaker",
+									"Title": "s:string",
+									"IsVisible": "s:boolean",
+									"IsCustomContentVisible": "s:boolean",
+									"CustomContent": "s:string",
+									"IsAgendaItemsSectionVisible": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"DirectoriesTab": {
+									"TabType": "EventWebsiteTabType|s:string|Summary,Lodging,Agenda,Directory,Custom,Speaker",
+									"Title": "s:string",
+									"IsVisible": "s:boolean",
+									"IsCustomContentVisible": "s:boolean",
+									"CustomContent": "s:string",
+									"IsDirectoriesSectionVisible": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsForCustomField": {
+				"input": {
+					"eventID": "s:int",
+					"cfid": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetRegistrationsForCustomFieldResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsForAgenda": {
+				"input": {
+					"eventID": "s:int",
+					"cfid": "s:int",
+					"filter": "s:string"
+				},
+				"output": {
+					"GetRegistrationsForAgendaResult": {
+						"APIRegistration[]": {
+							"ID": "s:int",
+							"EventID": "s:int",
+							"GroupID": "s:int",
+							"RegTypeID": "s:int",
+							"RegistrationType": "s:string",
+							"RegTypeDescription": "s:string",
+							"StatusID": "s:int",
+							"StatusDescription": "s:string",
+							"Prefix": "s:string",
+							"FirstName": "s:string",
+							"MiddleName": "s:string",
+							"LastName": "s:string",
+							"Suffix": "s:string",
+							"Title": "s:string",
+							"Email": "s:string",
+							"Company": "s:string",
+							"Address1": "s:string",
+							"Address2": "s:string",
+							"Address3": "s:string",
+							"City": "s:string",
+							"State": "s:string",
+							"Country": "s:string",
+							"PostalCode": "s:string",
+							"BalanceDue": "s:decimal",
+							"Phone": "s:string",
+							"HomePhone": "s:string",
+							"Extension": "s:string",
+							"Fax": "s:string",
+							"CellPhone": "s:string",
+							"CCEmail": "s:string",
+							"BadgeName": "s:string",
+							"CustID": "s:string",
+							"Photo": "s:string",
+							"DateOfBirth": "s:dateTime",
+							"Gender": "s:string",
+							"NationalityID": "s:int",
+							"Nationality": "s:string",
+							"RoomSharerID": "s:int",
+							"MembershipID": "s:string",
+							"CheckedIn": "s:boolean",
+							"CancelDate": "s:dateTime",
+							"DirectoryOptOut": "s:boolean",
+							"IsSubstitute": "s:boolean",
+							"Notes": "s:string",
+							"AddBy": "s:string",
+							"AddDate": "s:dateTime",
+							"ModBy": "s:string",
+							"ModDate": "s:dateTime",
+							"PaymentDocNumber": "s:string",
+							"GoogleVariableValue": "s:string",
+							"APIToken": "s:string",
+							"SessionId": "s:string",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistration": {
+				"input": {
+					"registrationID": "s:string"
+				},
+				"output": {
+					"GetRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetRegistrationsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsMerchandiseForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetRegistrationsMerchandiseForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrations": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetRegistrationsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetIncompleteRegistrations": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetIncompleteRegistrationsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetIncompleteRegistrationsForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetIncompleteRegistrationsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"ContactEventOrganizer": {
+				"input": {
+					"message": "s:string",
+					"eventID": "s:int",
+					"registrationID": "s:int"
+				},
+				"output": {
+					"ContactEventOrganizerResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"boolean[]": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetTransactions": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetTransactionsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APITransaction[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"RegistrationID": "s:int",
+								"Date": "s:dateTime",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"Amount": "s:decimal",
+								"EventCurrency": "s:string",
+								"GatewayAmount": "s:decimal",
+								"GatewayCurrency": "s:string",
+								"CCName": "s:string",
+								"CCType": "s:string",
+								"CCLast4": "s:string",
+								"CCExpDate": "s:dateTime",
+								"AuthCode": "s:string",
+								"GatewayTxnID": "s:string",
+								"Gateway": "s:string",
+								"SystemNotes": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetTransaction": {
+				"input": {
+					"ID": "s:int"
+				},
+				"output": {
+					"GetTransactionResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APITransaction[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"RegistrationID": "s:int",
+								"Date": "s:dateTime",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"Amount": "s:decimal",
+								"EventCurrency": "s:string",
+								"GatewayAmount": "s:decimal",
+								"GatewayCurrency": "s:string",
+								"CCName": "s:string",
+								"CCType": "s:string",
+								"CCLast4": "s:string",
+								"CCExpDate": "s:dateTime",
+								"AuthCode": "s:string",
+								"GatewayTxnID": "s:string",
+								"Gateway": "s:string",
+								"SystemNotes": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetTransactionsForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetTransactionsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APITransaction[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"RegistrationID": "s:int",
+								"Date": "s:dateTime",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"Amount": "s:decimal",
+								"EventCurrency": "s:string",
+								"GatewayAmount": "s:decimal",
+								"GatewayCurrency": "s:string",
+								"CCName": "s:string",
+								"CCType": "s:string",
+								"CCLast4": "s:string",
+								"CCExpDate": "s:dateTime",
+								"AuthCode": "s:string",
+								"GatewayTxnID": "s:string",
+								"Gateway": "s:string",
+								"SystemNotes": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFields": {
+				"input": {
+					"eventID": "s:int",
+					"pageSectionID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomFieldsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomField[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"PageSectionID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Details": "s:string",
+								"Location": "s:string",
+								"StartDate": "s:dateTime",
+								"StartDateString": "s:string",
+								"EndDate": "s:dateTime",
+								"Amount": "s:decimal",
+								"Capacity": "s:int",
+								"ZOrder": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetAgendaItems": {
+				"input": {
+					"eventID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetAgendaItemsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomField[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"PageSectionID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Details": "s:string",
+								"Location": "s:string",
+								"StartDate": "s:dateTime",
+								"StartDateString": "s:string",
+								"EndDate": "s:dateTime",
+								"Amount": "s:decimal",
+								"Capacity": "s:int",
+								"ZOrder": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFieldListItems": {
+				"input": {
+					"eventID": "s:int",
+					"cfID": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomFieldListItemsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomFieldListItem[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"CFID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Price": "s:decimal",
+								"Capacity": "s:int",
+								"PerGroupLimit": "s:int",
+								"IsVisible": "s:boolean",
+								"Order": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFieldsForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"pageSectionID": "s:int"
+				},
+				"output": {
+					"GetCustomFieldsForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomField[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"PageSectionID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Details": "s:string",
+								"Location": "s:string",
+								"StartDate": "s:dateTime",
+								"StartDateString": "s:string",
+								"EndDate": "s:dateTime",
+								"Amount": "s:decimal",
+								"Capacity": "s:int",
+								"ZOrder": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetAgendaItemsForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int"
+				},
+				"output": {
+					"GetAgendaItemsForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomField[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"PageSectionID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Details": "s:string",
+								"Location": "s:string",
+								"StartDate": "s:dateTime",
+								"StartDateString": "s:string",
+								"EndDate": "s:dateTime",
+								"Amount": "s:decimal",
+								"Capacity": "s:int",
+								"ZOrder": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetAgendaItemResponsesForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetAgendaItemResponsesForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomFieldResponse[]": {
+								"EventID": "s:int",
+								"CFID": "s:int",
+								"PageSectionID": "s:int",
+								"RegistrationID": "s:int",
+								"Response": "s:string",
+								"CustomFieldStatus": "s:string",
+								"CustomFieldStatusID": "s:int",
+								"ItemDescription": "s:string",
+								"ItemID": "s:int",
+								"Amount": "s:decimal",
+								"Password": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"WaitlistOrder": "s:dateTime",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"IsEarlyBird": "s:unsignedByte",
+								"TaxRate1": "s:decimal",
+								"TaxRate2": "s:decimal",
+								"TaxRateTypeID": "s:short",
+								"GroupDiscountCredit": "s:decimal",
+								"DiscountCodeCredit": "s:decimal",
+								"DiscountCodeCreditSaved": "s:boolean",
+								"CustomFieldNameOnReport": "s:string",
+								"CustomFieldNameOnForm": "s:string",
+								"CustomFieldStartDate": "s:dateTime",
+								"CustomFieldEndDate": "s:dateTime",
+								"CustomFieldLocation": "s:string",
+								"CustomFieldTypeID": "s:int",
+								"CustomFieldZOrder": "s:int",
+								"TaxAmount1": "s:decimal",
+								"TaxAmount2": "s:decimal",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"UpdateAgendaItemResponsesForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"agendaItemResponses": {
+						"APICustomFieldResponse[]": {
+							"EventID": "s:int",
+							"CFID": "s:int",
+							"PageSectionID": "s:int",
+							"RegistrationID": "s:int",
+							"Response": "s:string",
+							"CustomFieldStatus": "s:string",
+							"CustomFieldStatusID": "s:int",
+							"ItemDescription": "s:string",
+							"ItemID": "s:int",
+							"Amount": "s:decimal",
+							"Password": "s:string",
+							"IsWaitlisted": "s:boolean",
+							"WaitlistOrder": "s:dateTime",
+							"AddBy": "s:string",
+							"AddDate": "s:dateTime",
+							"ModBy": "s:string",
+							"ModDate": "s:dateTime",
+							"IsEarlyBird": "s:unsignedByte",
+							"TaxRate1": "s:decimal",
+							"TaxRate2": "s:decimal",
+							"TaxRateTypeID": "s:short",
+							"GroupDiscountCredit": "s:decimal",
+							"DiscountCodeCredit": "s:decimal",
+							"DiscountCodeCreditSaved": "s:boolean",
+							"CustomFieldNameOnReport": "s:string",
+							"CustomFieldNameOnForm": "s:string",
+							"CustomFieldStartDate": "s:dateTime",
+							"CustomFieldEndDate": "s:dateTime",
+							"CustomFieldLocation": "s:string",
+							"CustomFieldTypeID": "s:int",
+							"CustomFieldZOrder": "s:int",
+							"TaxAmount1": "s:decimal",
+							"TaxAmount2": "s:decimal",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				},
+				"output": {
+					"UpdateAgendaItemResponsesForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFieldResponses": {
+				"input": {
+					"eventID": "s:int",
+					"cfID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomFieldResponsesResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomFieldResponse[]": {
+								"EventID": "s:int",
+								"CFID": "s:int",
+								"PageSectionID": "s:int",
+								"RegistrationID": "s:int",
+								"Response": "s:string",
+								"CustomFieldStatus": "s:string",
+								"CustomFieldStatusID": "s:int",
+								"ItemDescription": "s:string",
+								"ItemID": "s:int",
+								"Amount": "s:decimal",
+								"Password": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"WaitlistOrder": "s:dateTime",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"IsEarlyBird": "s:unsignedByte",
+								"TaxRate1": "s:decimal",
+								"TaxRate2": "s:decimal",
+								"TaxRateTypeID": "s:short",
+								"GroupDiscountCredit": "s:decimal",
+								"DiscountCodeCredit": "s:decimal",
+								"DiscountCodeCreditSaved": "s:boolean",
+								"CustomFieldNameOnReport": "s:string",
+								"CustomFieldNameOnForm": "s:string",
+								"CustomFieldStartDate": "s:dateTime",
+								"CustomFieldEndDate": "s:dateTime",
+								"CustomFieldLocation": "s:string",
+								"CustomFieldTypeID": "s:int",
+								"CustomFieldZOrder": "s:int",
+								"TaxAmount1": "s:decimal",
+								"TaxAmount2": "s:decimal",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFieldResponsesForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"pageSectionID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomFieldResponsesForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomFieldResponse[]": {
+								"EventID": "s:int",
+								"CFID": "s:int",
+								"PageSectionID": "s:int",
+								"RegistrationID": "s:int",
+								"Response": "s:string",
+								"CustomFieldStatus": "s:string",
+								"CustomFieldStatusID": "s:int",
+								"ItemDescription": "s:string",
+								"ItemID": "s:int",
+								"Amount": "s:decimal",
+								"Password": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"WaitlistOrder": "s:dateTime",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"IsEarlyBird": "s:unsignedByte",
+								"TaxRate1": "s:decimal",
+								"TaxRate2": "s:decimal",
+								"TaxRateTypeID": "s:short",
+								"GroupDiscountCredit": "s:decimal",
+								"DiscountCodeCredit": "s:decimal",
+								"DiscountCodeCreditSaved": "s:boolean",
+								"CustomFieldNameOnReport": "s:string",
+								"CustomFieldNameOnForm": "s:string",
+								"CustomFieldStartDate": "s:dateTime",
+								"CustomFieldEndDate": "s:dateTime",
+								"CustomFieldLocation": "s:string",
+								"CustomFieldTypeID": "s:int",
+								"CustomFieldZOrder": "s:int",
+								"TaxAmount1": "s:decimal",
+								"TaxAmount2": "s:decimal",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"UpdateCustomFieldResponsesForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"customFieldResponses": {
+						"APICustomFieldResponse[]": {
+							"EventID": "s:int",
+							"CFID": "s:int",
+							"PageSectionID": "s:int",
+							"RegistrationID": "s:int",
+							"Response": "s:string",
+							"CustomFieldStatus": "s:string",
+							"CustomFieldStatusID": "s:int",
+							"ItemDescription": "s:string",
+							"ItemID": "s:int",
+							"Amount": "s:decimal",
+							"Password": "s:string",
+							"IsWaitlisted": "s:boolean",
+							"WaitlistOrder": "s:dateTime",
+							"AddBy": "s:string",
+							"AddDate": "s:dateTime",
+							"ModBy": "s:string",
+							"ModDate": "s:dateTime",
+							"IsEarlyBird": "s:unsignedByte",
+							"TaxRate1": "s:decimal",
+							"TaxRate2": "s:decimal",
+							"TaxRateTypeID": "s:short",
+							"GroupDiscountCredit": "s:decimal",
+							"DiscountCodeCredit": "s:decimal",
+							"DiscountCodeCreditSaved": "s:boolean",
+							"CustomFieldNameOnReport": "s:string",
+							"CustomFieldNameOnForm": "s:string",
+							"CustomFieldStartDate": "s:dateTime",
+							"CustomFieldEndDate": "s:dateTime",
+							"CustomFieldLocation": "s:string",
+							"CustomFieldTypeID": "s:int",
+							"CustomFieldZOrder": "s:int",
+							"TaxAmount1": "s:decimal",
+							"TaxAmount2": "s:decimal",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				},
+				"output": {
+					"UpdateCustomFieldResponsesForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			}
+		},
+		"RegOnline_x0020_APISoap12": {
+			"CheckinRegistrationsForEvent": {
+				"input": {
+					"registrationIDs": "s:string"
+				},
+				"output": {
+					"CheckinRegistrationsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"CheckinRegistrationsForAgendaItem": {
+				"input": {
+					"registrationIDs": "s:string",
+					"agendaItemID": "s:int",
+					"eventID": "s:int"
+				},
+				"output": {
+					"CheckinRegistrationsForAgendaItemResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"UpdateRegistration": {
+				"input": {
+					"registration": {
+						"ID": "s:int",
+						"EventID": "s:int",
+						"GroupID": "s:int",
+						"RegTypeID": "s:int",
+						"RegistrationType": "s:string",
+						"RegTypeDescription": "s:string",
+						"StatusID": "s:int",
+						"StatusDescription": "s:string",
+						"Prefix": "s:string",
+						"FirstName": "s:string",
+						"MiddleName": "s:string",
+						"LastName": "s:string",
+						"Suffix": "s:string",
+						"Title": "s:string",
+						"Email": "s:string",
+						"Company": "s:string",
+						"Address1": "s:string",
+						"Address2": "s:string",
+						"Address3": "s:string",
+						"City": "s:string",
+						"State": "s:string",
+						"Country": "s:string",
+						"PostalCode": "s:string",
+						"BalanceDue": "s:decimal",
+						"Phone": "s:string",
+						"HomePhone": "s:string",
+						"Extension": "s:string",
+						"Fax": "s:string",
+						"CellPhone": "s:string",
+						"CCEmail": "s:string",
+						"BadgeName": "s:string",
+						"CustID": "s:string",
+						"Photo": "s:string",
+						"DateOfBirth": "s:dateTime",
+						"Gender": "s:string",
+						"NationalityID": "s:int",
+						"Nationality": "s:string",
+						"RoomSharerID": "s:int",
+						"MembershipID": "s:string",
+						"CheckedIn": "s:boolean",
+						"CancelDate": "s:dateTime",
+						"DirectoryOptOut": "s:boolean",
+						"IsSubstitute": "s:boolean",
+						"Notes": "s:string",
+						"AddBy": "s:string",
+						"AddDate": "s:dateTime",
+						"ModBy": "s:string",
+						"ModDate": "s:dateTime",
+						"PaymentDocNumber": "s:string",
+						"GoogleVariableValue": "s:string",
+						"APIToken": "s:string",
+						"SessionId": "s:string",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				},
+				"output": {
+					"UpdateRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomReportsForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomReportsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomReport[]": {
+								"ID": "s:int",
+								"Name": "s:string",
+								"EventID": "s:int",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomReports": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomReportsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomReport[]": {
+								"ID": "s:int",
+								"Name": "s:string",
+								"EventID": "s:int",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetDirectories": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int"
+				},
+				"output": {
+					"GetDirectoriesResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomReport[]": {
+								"ID": "s:int",
+								"Name": "s:string",
+								"EventID": "s:int",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetDirectory": {
+				"input": {
+					"directoryID": "s:int",
+					"eventID": "s:int",
+					"registrationID": "s:int"
+				},
+				"output": {
+					"GetDirectoryResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GetAttendeeMobileAppSettings": {
+				"input": {
+					"eventID": "s:int",
+					"accessCode": "s:string"
+				},
+				"output": {
+					"_GetAttendeeMobileAppSettingsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"eventtitle": "s:string",
+							"eventid": "s:int",
+							"customerid": "s:int",
+							"isnewuxevent": "s:boolean",
+							"eventaddress": "s:string",
+							"allowupdates": "s:boolean",
+							"allowpartialupdates": "s:boolean",
+							"url": "s:string",
+							"hidecontactinfo": "s:boolean",
+							"showyelp": "s:boolean",
+							"floormap": "s:string",
+							"errorcode": "s:int",
+							"statusmsg": "s:string",
+							"updateurl": "s:string",
+							"passwordurl": "s:string",
+							"locations": {
+								"location[]": {
+									"name": "s:string",
+									"type": "s:string",
+									"address": "s:string",
+									"icon": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"social": {
+								"twitter": {
+									"enabled": "s:boolean",
+									"hashtag": "s:string",
+									"widgetId": "s:string",
+									"defaulttweet": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"facebook": {
+									"enabled": "s:boolean",
+									"apikey": "s:string",
+									"pageid": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"linkedin": {
+									"enabled": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"style": {
+								"bgcolor": "s:string",
+								"textcolor": "s:string",
+								"linkcolor": "s:string",
+								"headerbgcolor": "s:string",
+								"headertextcolor": "s:string",
+								"headerhtml": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"culture": "s:string",
+							"resources": {
+								"resource[]": {
+									"key": "s:string",
+									"value": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"logging": "s:boolean",
+							"googlewebpropertyid": "s:string",
+							"googlevariableindex": "s:int",
+							"goolgevariablename": "s:string",
+							"showeucookieribbon": "s:boolean",
+							"isGuestLoginEnabledOnEvent": "s:boolean",
+							"isEventEligibleForGuest": "s:boolean",
+							"logoImageSrc": "s:string",
+							"logoLinkUrl": "s:string",
+							"isPasswordEnabledOnCustomer": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GetOrganizerMobileAppSettings": {
+				"input": {},
+				"output": {
+					"_GetOrganizerMobileAppSettingsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"resources": {
+								"setting[]": {
+									"key": "s:string",
+									"value": "s:string",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"showeucookieribbon": "s:boolean",
+							"IsEnableLanyon": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"ValidateSFUser": {
+				"input": {
+					"userId": "s:string",
+					"token": "s:string"
+				},
+				"output": {
+					"ValidateSFUserResult": "s:int"
+				}
+			},
+			"UpdateEvent": {
+				"input": {
+					"updateEvent": {
+						"Id": "s:int",
+						"Title": "s:string",
+						"StartDate": "s:string",
+						"StartTime": "s:string",
+						"EndDate": "s:string",
+						"EndTime": "s:string",
+						"ClientEventId": "s:string",
+						"EventFee": "s:decimal",
+						"City": "s:string",
+						"State": "s:string",
+						"Country": "s:string",
+						"PostalCode": "s:string",
+						"LocationName": "s:string",
+						"LocationPhone": "s:string",
+						"LocationAddress1": "s:string",
+						"LocationAddress2": "s:string",
+						"ContactEmailAddress": "s:string",
+						"TimeZone": "s:string",
+						"Capacity": "s:int",
+						"CurrencyCode": "s:string",
+						"RegistrationTarget": "s:int",
+						"InternalNotes": "s:string",
+						"RegistrationFormUrl": "s:string",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				},
+				"output": {
+					"UpdateEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"ID": "s:int",
+							"CustomerID": "s:int",
+							"ParentID": "s:int",
+							"Status": "s:string",
+							"Title": "s:string",
+							"StartDate": "s:dateTime",
+							"EndDate": "s:dateTime",
+							"ActiveDate": "s:dateTime",
+							"ClientEventID": "s:string",
+							"TypeID": "s:int",
+							"Type": "s:string",
+							"City": "s:string",
+							"State": "s:string",
+							"Country": "s:string",
+							"CountryCode": "s:string",
+							"PostalCode": "s:string",
+							"LocationName": "s:string",
+							"LocationRoom": "s:string",
+							"LocationPhone": "s:string",
+							"LocationBuilding": "s:string",
+							"LocationAddress1": "s:string",
+							"LocationAddress2": "s:string",
+							"TimeZone": "s:string",
+							"Capacity": "s:int",
+							"CurrencyCode": "s:string",
+							"Keywords": "s:string",
+							"AddDate": "s:dateTime",
+							"AddBy": "s:string",
+							"ModDate": "s:dateTime",
+							"ModBy": "s:string",
+							"Channel": "s:string",
+							"IsWaitlisted": "s:boolean",
+							"Culture": "s:string",
+							"MediaType": "s:string",
+							"IsActive": "s:boolean",
+							"IsOnSite": "s:boolean",
+							"Latitude": "s:decimal",
+							"Longitude": "s:decimal",
+							"FloorMap": "s:string",
+							"InternalNotes": "s:string",
+							"TotalRevenue": "s:decimal",
+							"TotalRegistrations": "s:int",
+							"TotalCancels": "s:int",
+							"TotalSubstitutions": "s:int",
+							"TargetAttendance": "s:int",
+							"TotalIncompletes": "s:int",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsByEventID": {
+				"input": {
+					"eventID": "s:int",
+					"filter": "s:string"
+				},
+				"output": {
+					"GetRegistrationsByEventIDResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"Login": {
+				"input": {
+					"username": "s:string",
+					"password": "s:string"
+				},
+				"output": {
+					"LoginResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"Success": "s:boolean",
+							"OutMessage": "s:string",
+							"RedirectUrl": "s:string",
+							"EventSessionId": "s:string",
+							"CustomerId": "s:int",
+							"DisplayCaptcha": "s:boolean",
+							"IsCustomerDeactivated": "s:boolean",
+							"APIToken": "s:string",
+							"Email": "s:string",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"LoginRegistrantForPost": {
+				"input": {},
+				"output": {}
+			},
+			"LoginRegistrant": {
+				"input": {
+					"eventID": "s:int",
+					"email": "s:string",
+					"password": "s:string"
+				},
+				"output": {
+					"LoginRegistrantResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GuestLogin": {
+				"input": {
+					"eventID": "s:int",
+					"email": "s:string",
+					"password": "s:string",
+					"glpk": "s:string",
+					"rie": "s:string"
+				},
+				"output": {
+					"_GuestLoginResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GuestLoginForPost": {
+				"input": {},
+				"output": {}
+			},
+			"_VerifyGuestLogin": {
+				"input": {
+					"eventId": "s:int",
+					"email": "s:string",
+					"glpk": "s:string",
+					"rie": "s:string"
+				},
+				"output": {
+					"_VerifyGuestLoginResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"isGuestRegistration": "s:boolean",
+							"isVerificationEmailSent": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_VerifyGuestLoginForPost": {
+				"input": {},
+				"output": {}
+			},
+			"_VerifyPasswordRequiredToAccess": {
+				"input": {
+					"eventId": "s:int",
+					"email": "s:string",
+					"glpk": "s:string",
+					"rie": "s:string"
+				},
+				"output": {
+					"_VerifyPasswordRequiredToAccessResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"isGuestRegistration": "s:boolean",
+							"isPasswordEnabled": "s:boolean",
+							"isVerificationEmailSent": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_VerifyPasswordRequiredToAccessForPost": {
+				"input": {},
+				"output": {}
+			},
+			"CopyEvent": {
+				"input": {
+					"eventId": "s:int"
+				},
+				"output": {
+					"CopyEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"ID": "s:int",
+							"CustomerID": "s:int",
+							"ParentID": "s:int",
+							"Status": "s:string",
+							"Title": "s:string",
+							"StartDate": "s:dateTime",
+							"EndDate": "s:dateTime",
+							"ActiveDate": "s:dateTime",
+							"ClientEventID": "s:string",
+							"TypeID": "s:int",
+							"Type": "s:string",
+							"City": "s:string",
+							"State": "s:string",
+							"Country": "s:string",
+							"CountryCode": "s:string",
+							"PostalCode": "s:string",
+							"LocationName": "s:string",
+							"LocationRoom": "s:string",
+							"LocationPhone": "s:string",
+							"LocationBuilding": "s:string",
+							"LocationAddress1": "s:string",
+							"LocationAddress2": "s:string",
+							"TimeZone": "s:string",
+							"Capacity": "s:int",
+							"CurrencyCode": "s:string",
+							"Keywords": "s:string",
+							"AddDate": "s:dateTime",
+							"AddBy": "s:string",
+							"ModDate": "s:dateTime",
+							"ModBy": "s:string",
+							"Channel": "s:string",
+							"IsWaitlisted": "s:boolean",
+							"Culture": "s:string",
+							"MediaType": "s:string",
+							"IsActive": "s:boolean",
+							"IsOnSite": "s:boolean",
+							"Latitude": "s:decimal",
+							"Longitude": "s:decimal",
+							"FloorMap": "s:string",
+							"InternalNotes": "s:string",
+							"TotalRevenue": "s:decimal",
+							"TotalRegistrations": "s:int",
+							"TotalCancels": "s:int",
+							"TotalSubstitutions": "s:int",
+							"TargetAttendance": "s:int",
+							"TotalIncompletes": "s:int",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetEvents": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetEventsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetPublicEvents": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetPublicEventsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetEvent": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"GetEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"_GetEventForUser": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"_GetEventForUserResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetSurveysForEvent": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"GetSurveysForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetEventStatistics": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"GetEventStatisticsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEvent[]": {
+								"ID": "s:int",
+								"CustomerID": "s:int",
+								"ParentID": "s:int",
+								"Status": "s:string",
+								"Title": "s:string",
+								"StartDate": "s:dateTime",
+								"EndDate": "s:dateTime",
+								"ActiveDate": "s:dateTime",
+								"ClientEventID": "s:string",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"CountryCode": "s:string",
+								"PostalCode": "s:string",
+								"LocationName": "s:string",
+								"LocationRoom": "s:string",
+								"LocationPhone": "s:string",
+								"LocationBuilding": "s:string",
+								"LocationAddress1": "s:string",
+								"LocationAddress2": "s:string",
+								"TimeZone": "s:string",
+								"Capacity": "s:int",
+								"CurrencyCode": "s:string",
+								"Keywords": "s:string",
+								"AddDate": "s:dateTime",
+								"AddBy": "s:string",
+								"ModDate": "s:dateTime",
+								"ModBy": "s:string",
+								"Channel": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"Culture": "s:string",
+								"MediaType": "s:string",
+								"IsActive": "s:boolean",
+								"IsOnSite": "s:boolean",
+								"Latitude": "s:decimal",
+								"Longitude": "s:decimal",
+								"FloorMap": "s:string",
+								"InternalNotes": "s:string",
+								"TotalRevenue": "s:decimal",
+								"TotalRegistrations": "s:int",
+								"TotalCancels": "s:int",
+								"TotalSubstitutions": "s:int",
+								"TargetAttendance": "s:int",
+								"TotalIncompletes": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetEventWebsite": {
+				"input": {
+					"eventID": "s:int"
+				},
+				"output": {
+					"GetEventWebsiteResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIEventWebsite[]": {
+								"EventID": "s:int",
+								"AreTabsVisible": "s:boolean",
+								"IsRegisterNowButtonVisible": "s:boolean",
+								"IsContactDetailsSectionVisible": "s:boolean",
+								"IsSpacesRemainingVisible": "s:boolean",
+								"IsEarlyBirdAvailableVisible": "s:boolean",
+								"IsAddToCalendarLinkVisible": "s:boolean",
+								"IsTellAFriendLinkVisible": "s:boolean",
+								"IsFeaturesSectionVisible": "s:boolean",
+								"IsGlobalHeaderVisible": "s:boolean",
+								"IsGlobalFooterVisible": "s:boolean",
+								"IsWebsiteHeaderVisible": "s:boolean",
+								"IsWebsiteFooterVisible": "s:boolean",
+								"WebsiteHeader": "s:string",
+								"WebsiteFooter": "s:string",
+								"SummaryTab": {
+									"TabType": "EventWebsiteTabType|s:string|Summary,Lodging,Agenda,Directory,Custom,Speaker",
+									"Title": "s:string",
+									"IsVisible": "s:boolean",
+									"IsCustomContentVisible": "s:boolean",
+									"CustomContent": "s:string",
+									"IsEventDetailSectionVisible": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"LodgingTab": {
+									"TabType": "EventWebsiteTabType|s:string|Summary,Lodging,Agenda,Directory,Custom,Speaker",
+									"Title": "s:string",
+									"IsVisible": "s:boolean",
+									"IsCustomContentVisible": "s:boolean",
+									"CustomContent": "s:string",
+									"IsLodgingInformationVisible": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"AgendaTab": {
+									"TabType": "EventWebsiteTabType|s:string|Summary,Lodging,Agenda,Directory,Custom,Speaker",
+									"Title": "s:string",
+									"IsVisible": "s:boolean",
+									"IsCustomContentVisible": "s:boolean",
+									"CustomContent": "s:string",
+									"IsAgendaItemsSectionVisible": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"DirectoriesTab": {
+									"TabType": "EventWebsiteTabType|s:string|Summary,Lodging,Agenda,Directory,Custom,Speaker",
+									"Title": "s:string",
+									"IsVisible": "s:boolean",
+									"IsCustomContentVisible": "s:boolean",
+									"CustomContent": "s:string",
+									"IsDirectoriesSectionVisible": "s:boolean",
+									"targetNSAlias": "tns",
+									"targetNamespace": "http://www.regonline.com/api"
+								},
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsForCustomField": {
+				"input": {
+					"eventID": "s:int",
+					"cfid": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetRegistrationsForCustomFieldResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsForAgenda": {
+				"input": {
+					"eventID": "s:int",
+					"cfid": "s:int",
+					"filter": "s:string"
+				},
+				"output": {
+					"GetRegistrationsForAgendaResult": {
+						"APIRegistration[]": {
+							"ID": "s:int",
+							"EventID": "s:int",
+							"GroupID": "s:int",
+							"RegTypeID": "s:int",
+							"RegistrationType": "s:string",
+							"RegTypeDescription": "s:string",
+							"StatusID": "s:int",
+							"StatusDescription": "s:string",
+							"Prefix": "s:string",
+							"FirstName": "s:string",
+							"MiddleName": "s:string",
+							"LastName": "s:string",
+							"Suffix": "s:string",
+							"Title": "s:string",
+							"Email": "s:string",
+							"Company": "s:string",
+							"Address1": "s:string",
+							"Address2": "s:string",
+							"Address3": "s:string",
+							"City": "s:string",
+							"State": "s:string",
+							"Country": "s:string",
+							"PostalCode": "s:string",
+							"BalanceDue": "s:decimal",
+							"Phone": "s:string",
+							"HomePhone": "s:string",
+							"Extension": "s:string",
+							"Fax": "s:string",
+							"CellPhone": "s:string",
+							"CCEmail": "s:string",
+							"BadgeName": "s:string",
+							"CustID": "s:string",
+							"Photo": "s:string",
+							"DateOfBirth": "s:dateTime",
+							"Gender": "s:string",
+							"NationalityID": "s:int",
+							"Nationality": "s:string",
+							"RoomSharerID": "s:int",
+							"MembershipID": "s:string",
+							"CheckedIn": "s:boolean",
+							"CancelDate": "s:dateTime",
+							"DirectoryOptOut": "s:boolean",
+							"IsSubstitute": "s:boolean",
+							"Notes": "s:string",
+							"AddBy": "s:string",
+							"AddDate": "s:dateTime",
+							"ModBy": "s:string",
+							"ModDate": "s:dateTime",
+							"PaymentDocNumber": "s:string",
+							"GoogleVariableValue": "s:string",
+							"APIToken": "s:string",
+							"SessionId": "s:string",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistration": {
+				"input": {
+					"registrationID": "s:string"
+				},
+				"output": {
+					"GetRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetRegistrationsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrationsMerchandiseForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetRegistrationsMerchandiseForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetRegistrations": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetRegistrationsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetIncompleteRegistrations": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetIncompleteRegistrationsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetIncompleteRegistrationsForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetIncompleteRegistrationsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APIRegistration[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"GroupID": "s:int",
+								"RegTypeID": "s:int",
+								"RegistrationType": "s:string",
+								"RegTypeDescription": "s:string",
+								"StatusID": "s:int",
+								"StatusDescription": "s:string",
+								"Prefix": "s:string",
+								"FirstName": "s:string",
+								"MiddleName": "s:string",
+								"LastName": "s:string",
+								"Suffix": "s:string",
+								"Title": "s:string",
+								"Email": "s:string",
+								"Company": "s:string",
+								"Address1": "s:string",
+								"Address2": "s:string",
+								"Address3": "s:string",
+								"City": "s:string",
+								"State": "s:string",
+								"Country": "s:string",
+								"PostalCode": "s:string",
+								"BalanceDue": "s:decimal",
+								"Phone": "s:string",
+								"HomePhone": "s:string",
+								"Extension": "s:string",
+								"Fax": "s:string",
+								"CellPhone": "s:string",
+								"CCEmail": "s:string",
+								"BadgeName": "s:string",
+								"CustID": "s:string",
+								"Photo": "s:string",
+								"DateOfBirth": "s:dateTime",
+								"Gender": "s:string",
+								"NationalityID": "s:int",
+								"Nationality": "s:string",
+								"RoomSharerID": "s:int",
+								"MembershipID": "s:string",
+								"CheckedIn": "s:boolean",
+								"CancelDate": "s:dateTime",
+								"DirectoryOptOut": "s:boolean",
+								"IsSubstitute": "s:boolean",
+								"Notes": "s:string",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"PaymentDocNumber": "s:string",
+								"GoogleVariableValue": "s:string",
+								"APIToken": "s:string",
+								"SessionId": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"ContactEventOrganizer": {
+				"input": {
+					"message": "s:string",
+					"eventID": "s:int",
+					"registrationID": "s:int"
+				},
+				"output": {
+					"ContactEventOrganizerResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"boolean[]": "s:boolean",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetTransactions": {
+				"input": {
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetTransactionsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APITransaction[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"RegistrationID": "s:int",
+								"Date": "s:dateTime",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"Amount": "s:decimal",
+								"EventCurrency": "s:string",
+								"GatewayAmount": "s:decimal",
+								"GatewayCurrency": "s:string",
+								"CCName": "s:string",
+								"CCType": "s:string",
+								"CCLast4": "s:string",
+								"CCExpDate": "s:dateTime",
+								"AuthCode": "s:string",
+								"GatewayTxnID": "s:string",
+								"Gateway": "s:string",
+								"SystemNotes": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetTransaction": {
+				"input": {
+					"ID": "s:int"
+				},
+				"output": {
+					"GetTransactionResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APITransaction[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"RegistrationID": "s:int",
+								"Date": "s:dateTime",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"Amount": "s:decimal",
+								"EventCurrency": "s:string",
+								"GatewayAmount": "s:decimal",
+								"GatewayCurrency": "s:string",
+								"CCName": "s:string",
+								"CCType": "s:string",
+								"CCLast4": "s:string",
+								"CCExpDate": "s:dateTime",
+								"AuthCode": "s:string",
+								"GatewayTxnID": "s:string",
+								"Gateway": "s:string",
+								"SystemNotes": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetTransactionsForEvent": {
+				"input": {
+					"eventID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetTransactionsForEventResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APITransaction[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"RegistrationID": "s:int",
+								"Date": "s:dateTime",
+								"TypeID": "s:int",
+								"Type": "s:string",
+								"Amount": "s:decimal",
+								"EventCurrency": "s:string",
+								"GatewayAmount": "s:decimal",
+								"GatewayCurrency": "s:string",
+								"CCName": "s:string",
+								"CCType": "s:string",
+								"CCLast4": "s:string",
+								"CCExpDate": "s:dateTime",
+								"AuthCode": "s:string",
+								"GatewayTxnID": "s:string",
+								"Gateway": "s:string",
+								"SystemNotes": "s:string",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFields": {
+				"input": {
+					"eventID": "s:int",
+					"pageSectionID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomFieldsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomField[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"PageSectionID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Details": "s:string",
+								"Location": "s:string",
+								"StartDate": "s:dateTime",
+								"StartDateString": "s:string",
+								"EndDate": "s:dateTime",
+								"Amount": "s:decimal",
+								"Capacity": "s:int",
+								"ZOrder": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetAgendaItems": {
+				"input": {
+					"eventID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetAgendaItemsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomField[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"PageSectionID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Details": "s:string",
+								"Location": "s:string",
+								"StartDate": "s:dateTime",
+								"StartDateString": "s:string",
+								"EndDate": "s:dateTime",
+								"Amount": "s:decimal",
+								"Capacity": "s:int",
+								"ZOrder": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFieldListItems": {
+				"input": {
+					"eventID": "s:int",
+					"cfID": "s:int",
+					"filter": "s:string",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomFieldListItemsResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomFieldListItem[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"CFID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Price": "s:decimal",
+								"Capacity": "s:int",
+								"PerGroupLimit": "s:int",
+								"IsVisible": "s:boolean",
+								"Order": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFieldsForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"pageSectionID": "s:int"
+				},
+				"output": {
+					"GetCustomFieldsForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomField[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"PageSectionID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Details": "s:string",
+								"Location": "s:string",
+								"StartDate": "s:dateTime",
+								"StartDateString": "s:string",
+								"EndDate": "s:dateTime",
+								"Amount": "s:decimal",
+								"Capacity": "s:int",
+								"ZOrder": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetAgendaItemsForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int"
+				},
+				"output": {
+					"GetAgendaItemsForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomField[]": {
+								"ID": "s:int",
+								"EventID": "s:int",
+								"PageSectionID": "s:int",
+								"NameOnForm": "s:string",
+								"NameOnReport": "s:string",
+								"Details": "s:string",
+								"Location": "s:string",
+								"StartDate": "s:dateTime",
+								"StartDateString": "s:string",
+								"EndDate": "s:dateTime",
+								"Amount": "s:decimal",
+								"Capacity": "s:int",
+								"ZOrder": "s:int",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetAgendaItemResponsesForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetAgendaItemResponsesForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomFieldResponse[]": {
+								"EventID": "s:int",
+								"CFID": "s:int",
+								"PageSectionID": "s:int",
+								"RegistrationID": "s:int",
+								"Response": "s:string",
+								"CustomFieldStatus": "s:string",
+								"CustomFieldStatusID": "s:int",
+								"ItemDescription": "s:string",
+								"ItemID": "s:int",
+								"Amount": "s:decimal",
+								"Password": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"WaitlistOrder": "s:dateTime",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"IsEarlyBird": "s:unsignedByte",
+								"TaxRate1": "s:decimal",
+								"TaxRate2": "s:decimal",
+								"TaxRateTypeID": "s:short",
+								"GroupDiscountCredit": "s:decimal",
+								"DiscountCodeCredit": "s:decimal",
+								"DiscountCodeCreditSaved": "s:boolean",
+								"CustomFieldNameOnReport": "s:string",
+								"CustomFieldNameOnForm": "s:string",
+								"CustomFieldStartDate": "s:dateTime",
+								"CustomFieldEndDate": "s:dateTime",
+								"CustomFieldLocation": "s:string",
+								"CustomFieldTypeID": "s:int",
+								"CustomFieldZOrder": "s:int",
+								"TaxAmount1": "s:decimal",
+								"TaxAmount2": "s:decimal",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"UpdateAgendaItemResponsesForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"agendaItemResponses": {
+						"APICustomFieldResponse[]": {
+							"EventID": "s:int",
+							"CFID": "s:int",
+							"PageSectionID": "s:int",
+							"RegistrationID": "s:int",
+							"Response": "s:string",
+							"CustomFieldStatus": "s:string",
+							"CustomFieldStatusID": "s:int",
+							"ItemDescription": "s:string",
+							"ItemID": "s:int",
+							"Amount": "s:decimal",
+							"Password": "s:string",
+							"IsWaitlisted": "s:boolean",
+							"WaitlistOrder": "s:dateTime",
+							"AddBy": "s:string",
+							"AddDate": "s:dateTime",
+							"ModBy": "s:string",
+							"ModDate": "s:dateTime",
+							"IsEarlyBird": "s:unsignedByte",
+							"TaxRate1": "s:decimal",
+							"TaxRate2": "s:decimal",
+							"TaxRateTypeID": "s:short",
+							"GroupDiscountCredit": "s:decimal",
+							"DiscountCodeCredit": "s:decimal",
+							"DiscountCodeCreditSaved": "s:boolean",
+							"CustomFieldNameOnReport": "s:string",
+							"CustomFieldNameOnForm": "s:string",
+							"CustomFieldStartDate": "s:dateTime",
+							"CustomFieldEndDate": "s:dateTime",
+							"CustomFieldLocation": "s:string",
+							"CustomFieldTypeID": "s:int",
+							"CustomFieldZOrder": "s:int",
+							"TaxAmount1": "s:decimal",
+							"TaxAmount2": "s:decimal",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				},
+				"output": {
+					"UpdateAgendaItemResponsesForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFieldResponses": {
+				"input": {
+					"eventID": "s:int",
+					"cfID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomFieldResponsesResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomFieldResponse[]": {
+								"EventID": "s:int",
+								"CFID": "s:int",
+								"PageSectionID": "s:int",
+								"RegistrationID": "s:int",
+								"Response": "s:string",
+								"CustomFieldStatus": "s:string",
+								"CustomFieldStatusID": "s:int",
+								"ItemDescription": "s:string",
+								"ItemID": "s:int",
+								"Amount": "s:decimal",
+								"Password": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"WaitlistOrder": "s:dateTime",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"IsEarlyBird": "s:unsignedByte",
+								"TaxRate1": "s:decimal",
+								"TaxRate2": "s:decimal",
+								"TaxRateTypeID": "s:short",
+								"GroupDiscountCredit": "s:decimal",
+								"DiscountCodeCredit": "s:decimal",
+								"DiscountCodeCreditSaved": "s:boolean",
+								"CustomFieldNameOnReport": "s:string",
+								"CustomFieldNameOnForm": "s:string",
+								"CustomFieldStartDate": "s:dateTime",
+								"CustomFieldEndDate": "s:dateTime",
+								"CustomFieldLocation": "s:string",
+								"CustomFieldTypeID": "s:int",
+								"CustomFieldZOrder": "s:int",
+								"TaxAmount1": "s:decimal",
+								"TaxAmount2": "s:decimal",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"GetCustomFieldResponsesForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"pageSectionID": "s:int",
+					"orderBy": "s:string"
+				},
+				"output": {
+					"GetCustomFieldResponsesForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": {
+							"APICustomFieldResponse[]": {
+								"EventID": "s:int",
+								"CFID": "s:int",
+								"PageSectionID": "s:int",
+								"RegistrationID": "s:int",
+								"Response": "s:string",
+								"CustomFieldStatus": "s:string",
+								"CustomFieldStatusID": "s:int",
+								"ItemDescription": "s:string",
+								"ItemID": "s:int",
+								"Amount": "s:decimal",
+								"Password": "s:string",
+								"IsWaitlisted": "s:boolean",
+								"WaitlistOrder": "s:dateTime",
+								"AddBy": "s:string",
+								"AddDate": "s:dateTime",
+								"ModBy": "s:string",
+								"ModDate": "s:dateTime",
+								"IsEarlyBird": "s:unsignedByte",
+								"TaxRate1": "s:decimal",
+								"TaxRate2": "s:decimal",
+								"TaxRateTypeID": "s:short",
+								"GroupDiscountCredit": "s:decimal",
+								"DiscountCodeCredit": "s:decimal",
+								"DiscountCodeCreditSaved": "s:boolean",
+								"CustomFieldNameOnReport": "s:string",
+								"CustomFieldNameOnForm": "s:string",
+								"CustomFieldStartDate": "s:dateTime",
+								"CustomFieldEndDate": "s:dateTime",
+								"CustomFieldLocation": "s:string",
+								"CustomFieldTypeID": "s:int",
+								"CustomFieldZOrder": "s:int",
+								"TaxAmount1": "s:decimal",
+								"TaxAmount2": "s:decimal",
+								"targetNSAlias": "tns",
+								"targetNamespace": "http://www.regonline.com/api"
+							},
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			},
+			"UpdateCustomFieldResponsesForRegistration": {
+				"input": {
+					"eventID": "s:int",
+					"registrationID": "s:int",
+					"customFieldResponses": {
+						"APICustomFieldResponse[]": {
+							"EventID": "s:int",
+							"CFID": "s:int",
+							"PageSectionID": "s:int",
+							"RegistrationID": "s:int",
+							"Response": "s:string",
+							"CustomFieldStatus": "s:string",
+							"CustomFieldStatusID": "s:int",
+							"ItemDescription": "s:string",
+							"ItemID": "s:int",
+							"Amount": "s:decimal",
+							"Password": "s:string",
+							"IsWaitlisted": "s:boolean",
+							"WaitlistOrder": "s:dateTime",
+							"AddBy": "s:string",
+							"AddDate": "s:dateTime",
+							"ModBy": "s:string",
+							"ModDate": "s:dateTime",
+							"IsEarlyBird": "s:unsignedByte",
+							"TaxRate1": "s:decimal",
+							"TaxRate2": "s:decimal",
+							"TaxRateTypeID": "s:short",
+							"GroupDiscountCredit": "s:decimal",
+							"DiscountCodeCredit": "s:decimal",
+							"DiscountCodeCreditSaved": "s:boolean",
+							"CustomFieldNameOnReport": "s:string",
+							"CustomFieldNameOnForm": "s:string",
+							"CustomFieldStartDate": "s:dateTime",
+							"CustomFieldEndDate": "s:dateTime",
+							"CustomFieldLocation": "s:string",
+							"CustomFieldTypeID": "s:int",
+							"CustomFieldZOrder": "s:int",
+							"TaxAmount1": "s:decimal",
+							"TaxAmount2": "s:decimal",
+							"targetNSAlias": "tns",
+							"targetNamespace": "http://www.regonline.com/api"
+						},
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				},
+				"output": {
+					"UpdateCustomFieldResponsesForRegistrationResult": {
+						"Success": "s:boolean",
+						"Message": "s:string",
+						"Data": "s:boolean",
+						"StatusCode": "s:int",
+						"Authority": "s:int",
+						"targetNSAlias": "tns",
+						"targetNamespace": "http://www.regonline.com/api"
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/soapServer/index.js
+++ b/tests/soapServer/index.js
@@ -1,12 +1,15 @@
 const http = require('http');
 const fs = require('fs');
 
+const _ = require('lodash');
+const needle = require('needle');
 const SOAP = require('soap');
 
 // SOAP.createClient(__dirname + '/regonline.wsdl', (err, client) => {
 // 	console.log(__dirname);
 // 	console.log(err);
-// 	console.log(require('util').inspect(client.describe(), { depth: null }));
+// 	const clientDescription = client.describe();
+// 	fs.writeFileSync(__dirname + '/describe.json', JSON.stringify(clientDescription, null, '\t'), 'utf8');
 // });
 
 const soapService = require('./soapService');
@@ -19,13 +22,36 @@ const server = http.createServer(function (request, response) {
 	response.end('404: Not Found: ' + request.url);
 });
 
-server.listen(8000);
-SOAP.listen(server, '/wsdl', soapService, wsdlXML, function () {
-	console.log('server initialized');
+const soapServer = SOAP.listen(server, '/wsdl', soapService, wsdlXML);
+
+soapServer.on('request', (req, methodName) => {
+	console.log('reqest', methodName);
 });
 
-const needle = require('needle');
+soapServer.on('response', (resp, methodName) => {
+	console.log('response', methodName);
+	console.log(resp);
+});
 
-needle.get('localhost:8000/wsdl', (err, res, data) => {
-	console.log(data.toString());
+
+const request = {
+	headers: {
+		'Content-Type': 'text/xml; charset=utf-8',
+		SOAPAction: '"http://www.regonline.com/api/GetEvents"'
+	},
+	body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:tns="http://www.regonline.com/api"><soap:Header><TokenHeader xmlns:undefined="http://www.regonline.com/api" xmlns="http://www.regonline.com/api"><APIToken>lO29j0in23WRCF9s3b6LvqARu1FCIhohPTVP4Pu1yom2y2h005KRAQ==</APIToken></TokenHeader></soap:Header><soap:Body><GetEvents xmlns="http://www.regonline.com/api"><orderBy>ID DESC</orderBy></GetEvents></soap:Body></soap:Envelope>'
+};
+
+server.listen(8000, null, null, () => {
+	console.log('server initialized');
+	console.log(_.keys(soapServer));
+	console.log(soapServer.path);
+	console.log(soapServer.services);
+
+	needle.post('localhost:8000/wsdl', request.body, { headers: request.headers }, (err, res, data) => {
+		console.log('res');
+		// console.log(res.statusCode);
+		console.log(res.body);
+		// console.log(data.toString());
+	});
 });

--- a/tests/soapServer/index.js
+++ b/tests/soapServer/index.js
@@ -46,6 +46,7 @@ class SOAPServer {
 
 }
 
+//Start/stop server if this file is directly invoked, i,e, `node index.js`
 if (require.main === module) {
 	const soapServer = new SOAPServer(8000);
 	soapServer.startServer();

--- a/tests/soapServer/index.js
+++ b/tests/soapServer/index.js
@@ -1,0 +1,31 @@
+const http = require('http');
+const fs = require('fs');
+
+const SOAP = require('soap');
+
+// SOAP.createClient(__dirname + '/regonline.wsdl', (err, client) => {
+// 	console.log(__dirname);
+// 	console.log(err);
+// 	console.log(require('util').inspect(client.describe(), { depth: null }));
+// });
+
+const soapService = require('./soapService');
+
+const wsdlXML = fs.readFileSync(__dirname + '/regonline.wsdl', 'utf8');
+
+//TODO - not finished
+//http server example
+const server = http.createServer(function (request, response) {
+	response.end('404: Not Found: ' + request.url);
+});
+
+server.listen(8000);
+SOAP.listen(server, '/wsdl', soapService, wsdlXML, function () {
+	console.log('server initialized');
+});
+
+const needle = require('needle');
+
+needle.get('localhost:8000/wsdl', (err, res, data) => {
+	console.log(data.toString());
+});

--- a/tests/soapServer/index.js
+++ b/tests/soapServer/index.js
@@ -18,20 +18,20 @@ const wsdlXML = fs.readFileSync(__dirname + '/regonline.wsdl', 'utf8');
 
 //TODO - not finished
 //http server example
-const server = http.createServer(function (request, response) {
-	response.end('404: Not Found: ' + request.url);
-});
-
-const soapServer = SOAP.listen(server, '/wsdl', soapService, wsdlXML);
-
-soapServer.on('request', (req, methodName) => {
-	console.log('reqest', methodName);
-});
-
-soapServer.on('response', (resp, methodName) => {
-	console.log('response', methodName);
-	console.log(resp);
-});
+// const server = http.createServer(function (request, response) {
+// 	response.end('404: Not Found: ' + request.url);
+// });
+//
+// const soapServer = SOAP.listen(server, '/wsdl', soapService, wsdlXML);
+//
+// soapServer.on('request', (req, methodName) => {
+// 	console.log('reqest', methodName);
+// });
+//
+// soapServer.on('response', (resp, methodName) => {
+// 	console.log('response', methodName);
+// 	console.log(resp);
+// });
 
 
 const request = {
@@ -42,16 +42,66 @@ const request = {
 	body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:tns="http://www.regonline.com/api"><soap:Header><TokenHeader xmlns:undefined="http://www.regonline.com/api" xmlns="http://www.regonline.com/api"><APIToken>lO29j0in23WRCF9s3b6LvqARu1FCIhohPTVP4Pu1yom2y2h005KRAQ==</APIToken></TokenHeader></soap:Header><soap:Body><GetEvents xmlns="http://www.regonline.com/api"><orderBy>ID DESC</orderBy></GetEvents></soap:Body></soap:Envelope>'
 };
 
-server.listen(8000, null, null, () => {
-	console.log('server initialized');
-	console.log(_.keys(soapServer));
-	console.log(soapServer.path);
-	console.log(soapServer.services);
+// server.listen(8000, null, null, () => {
+// 	console.log('server initialized');
+// 	console.log(_.keys(soapServer));
+// 	console.log(soapServer.path);
+// 	console.log(soapServer.services);
+//
+// 	needle.post('localhost:8000/wsdl', request.body, { headers: request.headers }, (err, res, data) => {
+// 		console.log('res');
+// 		// console.log(res.statusCode);
+// 		console.log(res.body);
+// 		// console.log(data.toString());
+// 	});
+// });
 
-	needle.post('localhost:8000/wsdl', request.body, { headers: request.headers }, (err, res, data) => {
-		console.log('res');
-		// console.log(res.statusCode);
-		console.log(res.body);
-		// console.log(data.toString());
-	});
+
+
+class SOAPServer {
+
+	constructor (port = 8000) {
+
+		this.port = port;
+		this.soapService = soapService;
+		this.wsdlXML = wsdlXML;
+
+		const server = this.server = http.createServer((request, response) => {
+			// response.end('404: Not Found: ' + request.url);
+			// if (request.url === '') {
+			//
+			// }
+			console.log(request.url);
+		});
+
+		this.soapServer = SOAP.listen(server, '/default.asmx', this.soapService, this.wsdlXML);
+
+		this.soapServer.on('request', (req, methodName) => {
+			console.log('reqest', methodName);
+		});
+	}
+
+	startServer (callback) {
+		this.server.listen(this.port, null, null, (...listenArgs) => {
+			//eslint-disable-next-line no-console
+			console.log(`SOAP server at port ${this.port} initialized.`);
+			callback(null);
+		});
+	}
+
+	stopServer (callback) {
+		this.server.close(() => {
+			//eslint-disable-next-line no-console
+			console.log(`SOAP server at port ${this.port} closed.`);
+			callback(null);
+		});
+	}
+
+}
+
+const soapServer = new SOAPServer(8000);
+soapServer.startServer(() => {
+
 });
+
+module.exports = SOAPServer;

--- a/tests/soapServer/index.js
+++ b/tests/soapServer/index.js
@@ -2,21 +2,11 @@ const http = require('http');
 const fs = require('fs');
 
 const _ = require('lodash');
-const needle = require('needle');
 const SOAP = require('soap');
-
-// SOAP.createClient(__dirname + '/regonline.wsdl', (err, client) => {
-// 	console.log(__dirname);
-// 	console.log(err);
-// 	const clientDescription = client.describe();
-// 	fs.writeFileSync(__dirname + '/describe.json', JSON.stringify(clientDescription, null, '\t'), 'utf8');
-// });
 
 const soapService = require('./soapService');
 
 const wsdlXML = fs.readFileSync(__dirname + '/regonline.wsdl', 'utf8');
-
-
 
 class SOAPServer {
 

--- a/tests/soapServer/index.js
+++ b/tests/soapServer/index.js
@@ -16,46 +16,6 @@ const soapService = require('./soapService');
 
 const wsdlXML = fs.readFileSync(__dirname + '/regonline.wsdl', 'utf8');
 
-//TODO - not finished
-//http server example
-// const server = http.createServer(function (request, response) {
-// 	response.end('404: Not Found: ' + request.url);
-// });
-//
-// const soapServer = SOAP.listen(server, '/wsdl', soapService, wsdlXML);
-//
-// soapServer.on('request', (req, methodName) => {
-// 	console.log('reqest', methodName);
-// });
-//
-// soapServer.on('response', (resp, methodName) => {
-// 	console.log('response', methodName);
-// 	console.log(resp);
-// });
-
-
-const request = {
-	headers: {
-		'Content-Type': 'text/xml; charset=utf-8',
-		SOAPAction: '"http://www.regonline.com/api/GetEvents"'
-	},
-	body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:tns="http://www.regonline.com/api"><soap:Header><TokenHeader xmlns:undefined="http://www.regonline.com/api" xmlns="http://www.regonline.com/api"><APIToken>lO29j0in23WRCF9s3b6LvqARu1FCIhohPTVP4Pu1yom2y2h005KRAQ==</APIToken></TokenHeader></soap:Header><soap:Body><GetEvents xmlns="http://www.regonline.com/api"><orderBy>ID DESC</orderBy></GetEvents></soap:Body></soap:Envelope>'
-};
-
-// server.listen(8000, null, null, () => {
-// 	console.log('server initialized');
-// 	console.log(_.keys(soapServer));
-// 	console.log(soapServer.path);
-// 	console.log(soapServer.services);
-//
-// 	needle.post('localhost:8000/wsdl', request.body, { headers: request.headers }, (err, res, data) => {
-// 		console.log('res');
-// 		// console.log(res.statusCode);
-// 		console.log(res.body);
-// 		// console.log(data.toString());
-// 	});
-// });
-
 
 
 class SOAPServer {
@@ -67,25 +27,22 @@ class SOAPServer {
 		this.wsdlXML = wsdlXML;
 
 		const server = this.server = http.createServer((request, response) => {
-			// response.end('404: Not Found: ' + request.url);
-			// if (request.url === '') {
-			//
-			// }
-			console.log(request.url);
+			response.end('404: Not Found: ' + request.url);
 		});
 
 		this.soapServer = SOAP.listen(server, '/default.asmx', this.soapService, this.wsdlXML);
 
-		this.soapServer.on('request', (req, methodName) => {
-			console.log('reqest', methodName);
-		});
+		//Use this for debugging if needed
+		// this.soapServer.on('request', (req, methodName) => {
+		// 	console.log('reqest', methodName);
+		// });
 	}
 
 	startServer (callback) {
-		this.server.listen(this.port, null, null, (...listenArgs) => {
+		this.server.listen(this.port, null, null, () => {
 			//eslint-disable-next-line no-console
 			console.log(`SOAP server at port ${this.port} initialized.`);
-			callback(null);
+			if (_.isFunction(callback)) { callback(null); }
 		});
 	}
 
@@ -93,15 +50,22 @@ class SOAPServer {
 		this.server.close(() => {
 			//eslint-disable-next-line no-console
 			console.log(`SOAP server at port ${this.port} closed.`);
-			callback(null);
+			if (_.isFunction(callback)) { callback(null); }
 		});
 	}
 
 }
 
-const soapServer = new SOAPServer(8000);
-soapServer.startServer(() => {
+if (require.main === module) {
+	const soapServer = new SOAPServer(8000);
+	soapServer.startServer();
+	process.on('SIGINT', () => {
+		soapServer.stopServer(() => {
+			process.exit(2);
+		});
+	});
+}
 
-});
+
 
 module.exports = SOAPServer;

--- a/tests/soapServer/regonline.wsdl
+++ b/tests/soapServer/regonline.wsdl
@@ -1,0 +1,4750 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="http://www.regonline.com/api" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="http://www.regonline.com/api" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+    <wsdl:types>
+        <s:schema elementFormDefault="qualified" targetNamespace="http://www.regonline.com/api">
+            <s:element name="CheckinRegistrationsForEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="registrationIDs" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="CheckinRegistrationsForEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="CheckinRegistrationsForEventResult" type="tns:ResultsOfBoolean" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfBoolean">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Data" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="TokenHeader" type="tns:TokenHeader" />
+            <s:complexType name="TokenHeader">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="1" name="APIToken" type="s:string" />
+                </s:sequence>
+                <s:anyAttribute />
+            </s:complexType>
+            <s:element name="CheckinRegistrationsForAgendaItem">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="registrationIDs" type="s:string" />
+                        <s:element minOccurs="1" maxOccurs="1" name="agendaItemID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="CheckinRegistrationsForAgendaItemResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="CheckinRegistrationsForAgendaItemResult" type="tns:ResultsOfBoolean" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="UpdateRegistration">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="registration" type="tns:APIRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="APIRegistration">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:RegistrationCommonFields">
+                        <s:sequence>
+                            <s:element minOccurs="1" maxOccurs="1" name="ID" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="EventID" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="GroupID" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="RegTypeID" nillable="true" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="RegistrationType" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="RegTypeDescription" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="StatusID" nillable="true" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="StatusDescription" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Prefix" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="FirstName" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="MiddleName" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="LastName" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Suffix" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Title" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Email" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Company" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Address1" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Address2" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Address3" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="City" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="State" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Country" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="PostalCode" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="BalanceDue" type="s:decimal" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Phone" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="HomePhone" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Extension" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Fax" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CellPhone" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CCEmail" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="BadgeName" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CustID" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Photo" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="DateOfBirth" nillable="true" type="s:dateTime" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Gender" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="NationalityID" nillable="true" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Nationality" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="RoomSharerID" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="MembershipID" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="CheckedIn" nillable="true" type="s:boolean" />
+                            <s:element minOccurs="1" maxOccurs="1" name="CancelDate" nillable="true" type="s:dateTime" />
+                            <s:element minOccurs="1" maxOccurs="1" name="DirectoryOptOut" type="s:boolean" />
+                            <s:element minOccurs="1" maxOccurs="1" name="IsSubstitute" type="s:boolean" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Notes" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="AddBy" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="AddDate" type="s:dateTime" />
+                            <s:element minOccurs="0" maxOccurs="1" name="ModBy" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="ModDate" type="s:dateTime" />
+                            <s:element minOccurs="0" maxOccurs="1" name="PaymentDocNumber" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="GoogleVariableValue" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="APIToken" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="SessionId" type="s:string" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:complexType name="RegistrationCommonFields">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:AttendeeCommonFields" />
+                </s:complexContent>
+            </s:complexType>
+            <s:complexType name="AttendeeCommonFields">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:EventCommonFields" />
+                </s:complexContent>
+            </s:complexType>
+            <s:complexType name="EventCommonFields" />
+            <s:element name="UpdateRegistrationResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="UpdateRegistrationResult" type="tns:ResultsOfBoolean" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomReportsForEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomReportsForEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetCustomReportsForEventResult" type="tns:ResultsOfListOfCustomReport" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfCustomReport">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPICustomReport" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfAPICustomReport">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="APICustomReport" nillable="true" type="tns:APICustomReport" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="APICustomReport">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="ID" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Name" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="EventID" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="AddBy" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="AddDate" type="s:dateTime" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="GetCustomReports">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomReportsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetCustomReportsResult" type="tns:ResultsOfListOfCustomReport" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetDirectories">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" nillable="true" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetDirectoriesResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetDirectoriesResult" type="tns:ResultsOfListOfCustomReport" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetDirectory">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="directoryID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" nillable="true" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetDirectoryResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetDirectoryResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfRegistration">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPIRegistration" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfAPIRegistration">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="APIRegistration" nillable="true" type="tns:APIRegistration" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="GuestLoginResultsOfListOfRegistration">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:ResultsOfListOfRegistration">
+                        <s:sequence>
+                            <s:element minOccurs="1" maxOccurs="1" name="hasMultiRegs" type="s:boolean" />
+                            <s:element minOccurs="1" maxOccurs="1" name="hasGuestPassword" type="s:boolean" />
+                            <s:element minOccurs="1" maxOccurs="1" name="hasValidPublicPrivateKeys" type="s:boolean" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:element name="_GetAttendeeMobileAppSettings">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="accessCode" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="_GetAttendeeMobileAppSettingsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="_GetAttendeeMobileAppSettingsResult" type="tns:ResultsOfAttendeeMobileAppSettings" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfAttendeeMobileAppSettings">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:AttendeeMobileAppSettings" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="AttendeeMobileAppSettings">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="1" name="eventtitle" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="eventid" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="customerid" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="isnewuxevent" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="eventaddress" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="allowupdates" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="allowpartialupdates" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="url" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="hidecontactinfo" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="showyelp" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="floormap" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="errorcode" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="statusmsg" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="updateurl" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="passwordurl" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="locations" type="tns:ArrayOfLocation" />
+                    <s:element minOccurs="1" maxOccurs="1" name="social" type="tns:social_s" />
+                    <s:element minOccurs="1" maxOccurs="1" name="style" type="tns:style_s" />
+                    <s:element minOccurs="0" maxOccurs="1" name="culture" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="resources" type="tns:ArrayOfResource" />
+                    <s:element minOccurs="1" maxOccurs="1" name="logging" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="googlewebpropertyid" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="googlevariableindex" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="goolgevariablename" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="showeucookieribbon" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="isGuestLoginEnabledOnEvent" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="isEventEligibleForGuest" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="logoImageSrc" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="logoLinkUrl" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="isPasswordEnabledOnCustomer" type="s:boolean" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfLocation">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="location" type="tns:location" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="location">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="1" name="name" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="type" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="address" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="icon" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="social_s">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="twitter" type="tns:twitter" />
+                    <s:element minOccurs="1" maxOccurs="1" name="facebook" type="tns:facebook" />
+                    <s:element minOccurs="1" maxOccurs="1" name="linkedin" type="tns:linkedin" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="twitter">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="enabled" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="hashtag" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="widgetId" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="defaulttweet" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="facebook">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="enabled" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="apikey" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="pageid" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="linkedin">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="enabled" type="s:boolean" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="style_s">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="1" name="bgcolor" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="textcolor" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="linkcolor" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="headerbgcolor" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="headertextcolor" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="headerhtml" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfResource">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="resource" type="tns:resource" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="resource">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="1" name="key" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="value" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="_GetOrganizerMobileAppSettings">
+                <s:complexType />
+            </s:element>
+            <s:element name="_GetOrganizerMobileAppSettingsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="_GetOrganizerMobileAppSettingsResult" type="tns:ResultsOfOrganizerMobileAppSettings" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfOrganizerMobileAppSettings">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:OrganizerMobileAppSettings" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="OrganizerMobileAppSettings">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="1" name="resources" type="tns:ArrayOfSetting" />
+                    <s:element minOccurs="1" maxOccurs="1" name="showeucookieribbon" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsEnableLanyon" type="s:boolean" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfSetting">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="setting" type="tns:setting" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="setting">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="1" name="key" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="value" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="ValidateSFUser">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="userId" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="token" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="ValidateSFUserResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="ValidateSFUserResult" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="UpdateEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="updateEvent" type="tns:APIUpdateEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="APIUpdateEvent">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Id" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Title" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="StartDate" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="StartTime" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="EndDate" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="EndTime" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="ClientEventId" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="EventFee" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="0" maxOccurs="1" name="City" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="State" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Country" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="PostalCode" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="LocationName" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="LocationPhone" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="LocationAddress1" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="LocationAddress2" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="ContactEmailAddress" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="TimeZone" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Capacity" nillable="true" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="CurrencyCode" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="RegistrationTarget" nillable="true" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="InternalNotes" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="RegistrationFormUrl" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="UpdateEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="UpdateEventResult" type="tns:ResultsOfEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfEvent">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:APIEvent" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="APIEvent">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:EventCommonFields">
+                        <s:sequence>
+                            <s:element minOccurs="1" maxOccurs="1" name="ID" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="CustomerID" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="ParentID" nillable="true" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Status" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Title" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="StartDate" nillable="true" type="s:dateTime" />
+                            <s:element minOccurs="1" maxOccurs="1" name="EndDate" nillable="true" type="s:dateTime" />
+                            <s:element minOccurs="1" maxOccurs="1" name="ActiveDate" nillable="true" type="s:dateTime" />
+                            <s:element minOccurs="0" maxOccurs="1" name="ClientEventID" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="TypeID" nillable="true" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Type" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="City" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="State" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Country" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CountryCode" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="PostalCode" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="LocationName" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="LocationRoom" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="LocationPhone" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="LocationBuilding" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="LocationAddress1" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="LocationAddress2" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="TimeZone" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Capacity" nillable="true" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CurrencyCode" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Keywords" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="AddDate" type="s:dateTime" />
+                            <s:element minOccurs="0" maxOccurs="1" name="AddBy" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="ModDate" type="s:dateTime" />
+                            <s:element minOccurs="0" maxOccurs="1" name="ModBy" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Channel" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="IsWaitlisted" type="s:boolean" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Culture" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="MediaType" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="IsActive" type="s:boolean" />
+                            <s:element minOccurs="1" maxOccurs="1" name="IsOnSite" type="s:boolean" />
+                            <s:element minOccurs="1" maxOccurs="1" name="Latitude" nillable="true" type="s:decimal" />
+                            <s:element minOccurs="1" maxOccurs="1" name="Longitude" nillable="true" type="s:decimal" />
+                            <s:element minOccurs="0" maxOccurs="1" name="FloorMap" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="InternalNotes" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="TotalRevenue" nillable="true" type="s:decimal" />
+                            <s:element minOccurs="1" maxOccurs="1" name="TotalRegistrations" nillable="true" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="TotalCancels" nillable="true" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="TotalSubstitutions" nillable="true" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="TargetAttendance" nillable="true" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="TotalIncompletes" nillable="true" type="s:int" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:element name="GetRegistrationsByEventID">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsByEventIDResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetRegistrationsByEventIDResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="Login">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="username" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="password" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="LoginResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="LoginResult" type="tns:ResultsOfLoginResults" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfLoginResults">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:LoginResults" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="LoginResults">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:ResultsBase">
+                        <s:sequence>
+                            <s:element minOccurs="0" maxOccurs="1" name="RedirectUrl" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="EventSessionId" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="CustomerId" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="DisplayCaptcha" type="s:boolean" />
+                            <s:element minOccurs="1" maxOccurs="1" name="IsCustomerDeactivated" type="s:boolean" />
+                            <s:element minOccurs="0" maxOccurs="1" name="APIToken" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Email" type="s:string" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:complexType name="ResultsBase" abstract="true">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="OutMessage" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="LoginRegistrantForPost">
+                <s:complexType />
+            </s:element>
+            <s:element name="LoginRegistrantForPostResponse">
+                <s:complexType />
+            </s:element>
+            <s:element name="LoginRegistrant">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="email" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="password" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="LoginRegistrantResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="LoginRegistrantResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="_GuestLogin">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="email" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="password" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="glpk" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="rie" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="_GuestLoginResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="_GuestLoginResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="_GuestLoginForPost">
+                <s:complexType />
+            </s:element>
+            <s:element name="_GuestLoginForPostResponse">
+                <s:complexType />
+            </s:element>
+            <s:element name="_VerifyGuestLogin">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventId" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="email" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="glpk" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="rie" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="_VerifyGuestLoginResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="_VerifyGuestLoginResult" type="tns:ResultsOfVerifyGuestLoginResult" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfVerifyGuestLoginResult">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:VerifyGuestLoginResult" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="VerifyGuestLoginResult">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="isGuestRegistration" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="isVerificationEmailSent" type="s:boolean" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="_VerifyGuestLoginForPost">
+                <s:complexType />
+            </s:element>
+            <s:element name="_VerifyGuestLoginForPostResponse">
+                <s:complexType />
+            </s:element>
+            <s:element name="_VerifyPasswordRequiredToAccess">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventId" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="email" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="glpk" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="rie" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="_VerifyPasswordRequiredToAccessResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="_VerifyPasswordRequiredToAccessResult" type="tns:ResultsOfVerifyPasswordRequiredResult" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfVerifyPasswordRequiredResult">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:VerifyPasswordRequiredResult" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="VerifyPasswordRequiredResult">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="isGuestRegistration" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="isPasswordEnabled" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="isVerificationEmailSent" type="s:boolean" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="_VerifyPasswordRequiredToAccessForPost">
+                <s:complexType />
+            </s:element>
+            <s:element name="_VerifyPasswordRequiredToAccessForPostResponse">
+                <s:complexType />
+            </s:element>
+            <s:element name="CopyEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventId" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="CopyEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="CopyEventResult" type="tns:ResultsOfEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetEvents">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetEventsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetEventsResult" type="tns:ResultsOfListOfEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfEvent">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPIEvent" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfAPIEvent">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="APIEvent" nillable="true" type="tns:APIEvent" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="GetPublicEvents">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetPublicEventsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetPublicEventsResult" type="tns:ResultsOfListOfEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetEventResult" type="tns:ResultsOfListOfEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="_GetEventForUser">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="_GetEventForUserResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="_GetEventForUserResult" type="tns:ResultsOfListOfEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetSurveysForEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" nillable="true" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetSurveysForEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetSurveysForEventResult" type="tns:ResultsOfListOfEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetEventStatistics">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetEventStatisticsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetEventStatisticsResult" type="tns:ResultsOfListOfEvent" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetEventWebsite">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetEventWebsiteResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetEventWebsiteResult" type="tns:ResultsOfListOfEventWebsite" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfEventWebsite">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPIEventWebsite" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfAPIEventWebsite">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="APIEventWebsite" nillable="true" type="tns:APIEventWebsite" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="APIEventWebsite">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="EventID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="AreTabsVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsRegisterNowButtonVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsContactDetailsSectionVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsSpacesRemainingVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsEarlyBirdAvailableVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsAddToCalendarLinkVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsTellAFriendLinkVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsFeaturesSectionVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsGlobalHeaderVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsGlobalFooterVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsWebsiteHeaderVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsWebsiteFooterVisible" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="WebsiteHeader" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="WebsiteFooter" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="SummaryTab" type="tns:APIEventWebsiteSummaryTab" />
+                    <s:element minOccurs="0" maxOccurs="1" name="LodgingTab" type="tns:APIEventWebsiteLodgingTab" />
+                    <s:element minOccurs="0" maxOccurs="1" name="AgendaTab" type="tns:APIEventWebsiteAgendaTab" />
+                    <s:element minOccurs="0" maxOccurs="1" name="DirectoriesTab" type="tns:APIEventWebsiteDirectoriesTab" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="APIEventWebsiteSummaryTab">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:APIEventWebsiteTab">
+                        <s:sequence>
+                            <s:element minOccurs="1" maxOccurs="1" name="IsEventDetailSectionVisible" type="s:boolean" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:complexType name="APIEventWebsiteTab" abstract="true">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="TabType" type="tns:EventWebsiteTabType" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Title" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsCustomContentVisible" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="CustomContent" type="s:string" />
+                </s:sequence>
+            </s:complexType>
+            <s:simpleType name="EventWebsiteTabType">
+                <s:restriction base="s:string">
+                    <s:enumeration value="Summary" />
+                    <s:enumeration value="Lodging" />
+                    <s:enumeration value="Agenda" />
+                    <s:enumeration value="Directory" />
+                    <s:enumeration value="Custom" />
+                    <s:enumeration value="Speaker" />
+                </s:restriction>
+            </s:simpleType>
+            <s:complexType name="APIEventWebsiteDirectoriesTab">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:APIEventWebsiteTab">
+                        <s:sequence>
+                            <s:element minOccurs="1" maxOccurs="1" name="IsDirectoriesSectionVisible" type="s:boolean" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:complexType name="APIEventWebsiteAgendaTab">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:APIEventWebsiteTab">
+                        <s:sequence>
+                            <s:element minOccurs="1" maxOccurs="1" name="IsAgendaItemsSectionVisible" type="s:boolean" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:complexType name="APIEventWebsiteLodgingTab">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:APIEventWebsiteTab">
+                        <s:sequence>
+                            <s:element minOccurs="1" maxOccurs="1" name="IsLodgingInformationVisible" type="s:boolean" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:element name="GetRegistrationsForCustomField">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="cfid" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsForCustomFieldResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetRegistrationsForCustomFieldResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsForAgenda">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="cfid" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsForAgendaResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetRegistrationsForAgendaResult" type="tns:ArrayOfAPIRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistration">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="registrationID" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetRegistrationResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsForEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsForEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetRegistrationsForEventResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsMerchandiseForEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsMerchandiseForEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetRegistrationsMerchandiseForEventResult" type="tns:ResultsOfListOfRegistrationWithMerchandise" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfRegistrationWithMerchandise">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPIRegistration" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="GetRegistrations">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetRegistrationsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetRegistrationsResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetIncompleteRegistrations">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetIncompleteRegistrationsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetIncompleteRegistrationsResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetIncompleteRegistrationsForEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetIncompleteRegistrationsForEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetIncompleteRegistrationsForEventResult" type="tns:ResultsOfListOfRegistration" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="ContactEventOrganizer">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="message" type="s:string" />
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" nillable="true" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="ContactEventOrganizerResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="ContactEventOrganizerResult" type="tns:ResultsOfListOfBoolean" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfBoolean">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfBoolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfBoolean">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="boolean" type="s:boolean" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="GetTransactions">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetTransactionsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetTransactionsResult" type="tns:ResultsOfListOfTransaction" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfTransaction">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPITransaction" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfAPITransaction">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="APITransaction" nillable="true" type="tns:APITransaction" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="APITransaction">
+                <s:complexContent mixed="false">
+                    <s:extension base="tns:RegistrationCommonFields">
+                        <s:sequence>
+                            <s:element minOccurs="1" maxOccurs="1" name="ID" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="EventID" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="RegistrationID" type="s:int" />
+                            <s:element minOccurs="1" maxOccurs="1" name="Date" nillable="true" type="s:dateTime" />
+                            <s:element minOccurs="1" maxOccurs="1" name="TypeID" nillable="true" type="s:int" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Type" type="s:string" />
+                            <s:element minOccurs="1" maxOccurs="1" name="Amount" nillable="true" type="s:decimal" />
+                            <s:element minOccurs="0" maxOccurs="1" name="EventCurrency" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="GatewayAmount" nillable="true" type="s:decimal" />
+                            <s:element minOccurs="0" maxOccurs="1" name="GatewayCurrency" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CCName" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CCType" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CCLast4" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="CCExpDate" nillable="true" type="s:dateTime" />
+                            <s:element minOccurs="0" maxOccurs="1" name="AuthCode" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="GatewayTxnID" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="Gateway" type="s:string" />
+                            <s:element minOccurs="0" maxOccurs="1" name="SystemNotes" type="s:string" />
+                        </s:sequence>
+                    </s:extension>
+                </s:complexContent>
+            </s:complexType>
+            <s:element name="GetTransaction">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="ID" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetTransactionResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetTransactionResult" type="tns:ResultsOfListOfTransaction" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetTransactionsForEvent">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetTransactionsForEventResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetTransactionsForEventResult" type="tns:ResultsOfListOfTransaction" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFields">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="pageSectionID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFieldsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetCustomFieldsResult" type="tns:ResultsOfListOfCustomField" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfCustomField">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPICustomField" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfAPICustomField">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="APICustomField" nillable="true" type="tns:APICustomField" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="APICustomField">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="ID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="EventID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="PageSectionID" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="NameOnForm" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="NameOnReport" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Details" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Location" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StartDate" nillable="true" type="s:dateTime" />
+                    <s:element minOccurs="0" maxOccurs="1" name="StartDateString" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="EndDate" nillable="true" type="s:dateTime" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Amount" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Capacity" nillable="true" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="ZOrder" nillable="true" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="GetAgendaItems">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetAgendaItemsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetAgendaItemsResult" type="tns:ResultsOfListOfCustomField" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFieldListItems">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="cfID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="filter" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFieldListItemsResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetCustomFieldListItemsResult" type="tns:ResultsOfListOfCustomFieldListItem" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfCustomFieldListItem">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPICustomFieldListItem" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfAPICustomFieldListItem">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="APICustomFieldListItem" nillable="true" type="tns:APICustomFieldListItem" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="APICustomFieldListItem">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="ID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="EventID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="CFID" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="NameOnForm" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="NameOnReport" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Price" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Capacity" nillable="true" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="PerGroupLimit" nillable="true" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsVisible" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Order" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="GetCustomFieldsForRegistration">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="pageSectionID" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFieldsForRegistrationResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetCustomFieldsForRegistrationResult" type="tns:ResultsOfListOfCustomField" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetAgendaItemsForRegistration">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" nillable="true" type="s:int" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetAgendaItemsForRegistrationResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetAgendaItemsForRegistrationResult" type="tns:ResultsOfListOfCustomField" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetAgendaItemResponsesForRegistration">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" nillable="true" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetAgendaItemResponsesForRegistrationResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetAgendaItemResponsesForRegistrationResult" type="tns:ResultsOfListOfCustomFieldResponse" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:complexType name="ResultsOfListOfCustomFieldResponse">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="Success" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Message" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Data" type="tns:ArrayOfAPICustomFieldResponse" />
+                    <s:element minOccurs="1" maxOccurs="1" name="StatusCode" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Authority" type="s:int" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="ArrayOfAPICustomFieldResponse">
+                <s:sequence>
+                    <s:element minOccurs="0" maxOccurs="unbounded" name="APICustomFieldResponse" nillable="true" type="tns:APICustomFieldResponse" />
+                </s:sequence>
+            </s:complexType>
+            <s:complexType name="APICustomFieldResponse">
+                <s:sequence>
+                    <s:element minOccurs="1" maxOccurs="1" name="EventID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="CFID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="PageSectionID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="RegistrationID" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Response" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="CustomFieldStatus" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="CustomFieldStatusID" nillable="true" type="s:int" />
+                    <s:element minOccurs="0" maxOccurs="1" name="ItemDescription" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="ItemID" nillable="true" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="Amount" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="0" maxOccurs="1" name="Password" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsWaitlisted" nillable="true" type="s:boolean" />
+                    <s:element minOccurs="1" maxOccurs="1" name="WaitlistOrder" type="s:dateTime" />
+                    <s:element minOccurs="0" maxOccurs="1" name="AddBy" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="AddDate" type="s:dateTime" />
+                    <s:element minOccurs="0" maxOccurs="1" name="ModBy" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="ModDate" type="s:dateTime" />
+                    <s:element minOccurs="1" maxOccurs="1" name="IsEarlyBird" nillable="true" type="s:unsignedByte" />
+                    <s:element minOccurs="1" maxOccurs="1" name="TaxRate1" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="1" maxOccurs="1" name="TaxRate2" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="1" maxOccurs="1" name="TaxRateTypeID" nillable="true" type="s:short" />
+                    <s:element minOccurs="1" maxOccurs="1" name="GroupDiscountCredit" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="1" maxOccurs="1" name="DiscountCodeCredit" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="1" maxOccurs="1" name="DiscountCodeCreditSaved" nillable="true" type="s:boolean" />
+                    <s:element minOccurs="0" maxOccurs="1" name="CustomFieldNameOnReport" type="s:string" />
+                    <s:element minOccurs="0" maxOccurs="1" name="CustomFieldNameOnForm" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="CustomFieldStartDate" nillable="true" type="s:dateTime" />
+                    <s:element minOccurs="1" maxOccurs="1" name="CustomFieldEndDate" nillable="true" type="s:dateTime" />
+                    <s:element minOccurs="0" maxOccurs="1" name="CustomFieldLocation" type="s:string" />
+                    <s:element minOccurs="1" maxOccurs="1" name="CustomFieldTypeID" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="CustomFieldZOrder" nillable="true" type="s:int" />
+                    <s:element minOccurs="1" maxOccurs="1" name="TaxAmount1" nillable="true" type="s:decimal" />
+                    <s:element minOccurs="1" maxOccurs="1" name="TaxAmount2" nillable="true" type="s:decimal" />
+                </s:sequence>
+            </s:complexType>
+            <s:element name="UpdateAgendaItemResponsesForRegistration">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="agendaItemResponses" type="tns:ArrayOfAPICustomFieldResponse" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="UpdateAgendaItemResponsesForRegistrationResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="UpdateAgendaItemResponsesForRegistrationResult" type="tns:ResultsOfBoolean" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFieldResponses">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="cfID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFieldResponsesResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetCustomFieldResponsesResult" type="tns:ResultsOfListOfCustomFieldResponse" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFieldResponsesForRegistration">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" nillable="true" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="pageSectionID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="orderBy" type="s:string" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="GetCustomFieldResponsesForRegistrationResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="GetCustomFieldResponsesForRegistrationResult" type="tns:ResultsOfListOfCustomFieldResponse" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="UpdateCustomFieldResponsesForRegistration">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="1" maxOccurs="1" name="eventID" type="s:int" />
+                        <s:element minOccurs="1" maxOccurs="1" name="registrationID" type="s:int" />
+                        <s:element minOccurs="0" maxOccurs="1" name="customFieldResponses" type="tns:ArrayOfAPICustomFieldResponse" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="UpdateCustomFieldResponsesForRegistrationResponse">
+                <s:complexType>
+                    <s:sequence>
+                        <s:element minOccurs="0" maxOccurs="1" name="UpdateCustomFieldResponsesForRegistrationResult" type="tns:ResultsOfBoolean" />
+                    </s:sequence>
+                </s:complexType>
+            </s:element>
+            <s:element name="ResultsOfBoolean" nillable="true" type="tns:ResultsOfBoolean" />
+            <s:element name="ResultsOfListOfCustomReport" nillable="true" type="tns:ResultsOfListOfCustomReport" />
+            <s:element name="ResultsOfAttendeeMobileAppSettings" nillable="true" type="tns:ResultsOfAttendeeMobileAppSettings" />
+            <s:element name="ResultsOfOrganizerMobileAppSettings" nillable="true" type="tns:ResultsOfOrganizerMobileAppSettings" />
+            <s:element name="int" type="s:int" />
+            <s:element name="ResultsOfListOfRegistration" nillable="true" type="tns:ResultsOfListOfRegistration" />
+            <s:element name="ResultsOfLoginResults" nillable="true" type="tns:ResultsOfLoginResults" />
+            <s:element name="ResultsOfVerifyGuestLoginResult" nillable="true" type="tns:ResultsOfVerifyGuestLoginResult" />
+            <s:element name="ResultsOfVerifyPasswordRequiredResult" nillable="true" type="tns:ResultsOfVerifyPasswordRequiredResult" />
+            <s:element name="ResultsOfEvent" nillable="true" type="tns:ResultsOfEvent" />
+            <s:element name="ResultsOfListOfEvent" nillable="true" type="tns:ResultsOfListOfEvent" />
+            <s:element name="ResultsOfListOfEventWebsite" nillable="true" type="tns:ResultsOfListOfEventWebsite" />
+            <s:element name="ArrayOfAPIRegistration" nillable="true" type="tns:ArrayOfAPIRegistration" />
+            <s:element name="ResultsOfListOfRegistrationWithMerchandise" nillable="true" type="tns:ResultsOfListOfRegistrationWithMerchandise" />
+            <s:element name="ResultsOfListOfTransaction" nillable="true" type="tns:ResultsOfListOfTransaction" />
+            <s:element name="ResultsOfListOfCustomField" nillable="true" type="tns:ResultsOfListOfCustomField" />
+            <s:element name="ResultsOfListOfCustomFieldListItem" nillable="true" type="tns:ResultsOfListOfCustomFieldListItem" />
+            <s:element name="ResultsOfListOfCustomFieldResponse" nillable="true" type="tns:ResultsOfListOfCustomFieldResponse" />
+        </s:schema>
+    </wsdl:types>
+    <wsdl:message name="CheckinRegistrationsForEventSoapIn">
+        <wsdl:part name="parameters" element="tns:CheckinRegistrationsForEvent" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForEventSoapOut">
+        <wsdl:part name="parameters" element="tns:CheckinRegistrationsForEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForAgendaItemSoapIn">
+        <wsdl:part name="parameters" element="tns:CheckinRegistrationsForAgendaItem" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForAgendaItemSoapOut">
+        <wsdl:part name="parameters" element="tns:CheckinRegistrationsForAgendaItemResponse" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForAgendaItemTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="UpdateRegistrationSoapIn">
+        <wsdl:part name="parameters" element="tns:UpdateRegistration" />
+    </wsdl:message>
+    <wsdl:message name="UpdateRegistrationSoapOut">
+        <wsdl:part name="parameters" element="tns:UpdateRegistrationResponse" />
+    </wsdl:message>
+    <wsdl:message name="UpdateRegistrationTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsForEventSoapIn">
+        <wsdl:part name="parameters" element="tns:GetCustomReportsForEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsForEventSoapOut">
+        <wsdl:part name="parameters" element="tns:GetCustomReportsForEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsForEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetCustomReports" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetCustomReportsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetDirectoriesSoapIn">
+        <wsdl:part name="parameters" element="tns:GetDirectories" />
+    </wsdl:message>
+    <wsdl:message name="GetDirectoriesSoapOut">
+        <wsdl:part name="parameters" element="tns:GetDirectoriesResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetDirectoriesTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetDirectorySoapIn">
+        <wsdl:part name="parameters" element="tns:GetDirectory" />
+    </wsdl:message>
+    <wsdl:message name="GetDirectorySoapOut">
+        <wsdl:part name="parameters" element="tns:GetDirectoryResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetDirectoryTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="_GetAttendeeMobileAppSettingsSoapIn">
+        <wsdl:part name="parameters" element="tns:_GetAttendeeMobileAppSettings" />
+    </wsdl:message>
+    <wsdl:message name="_GetAttendeeMobileAppSettingsSoapOut">
+        <wsdl:part name="parameters" element="tns:_GetAttendeeMobileAppSettingsResponse" />
+    </wsdl:message>
+    <wsdl:message name="_GetOrganizerMobileAppSettingsSoapIn">
+        <wsdl:part name="parameters" element="tns:_GetOrganizerMobileAppSettings" />
+    </wsdl:message>
+    <wsdl:message name="_GetOrganizerMobileAppSettingsSoapOut">
+        <wsdl:part name="parameters" element="tns:_GetOrganizerMobileAppSettingsResponse" />
+    </wsdl:message>
+    <wsdl:message name="ValidateSFUserSoapIn">
+        <wsdl:part name="parameters" element="tns:ValidateSFUser" />
+    </wsdl:message>
+    <wsdl:message name="ValidateSFUserSoapOut">
+        <wsdl:part name="parameters" element="tns:ValidateSFUserResponse" />
+    </wsdl:message>
+    <wsdl:message name="UpdateEventSoapIn">
+        <wsdl:part name="parameters" element="tns:UpdateEvent" />
+    </wsdl:message>
+    <wsdl:message name="UpdateEventSoapOut">
+        <wsdl:part name="parameters" element="tns:UpdateEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="UpdateEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsByEventIDSoapIn">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsByEventID" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsByEventIDSoapOut">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsByEventIDResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsByEventIDTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="LoginSoapIn">
+        <wsdl:part name="parameters" element="tns:Login" />
+    </wsdl:message>
+    <wsdl:message name="LoginSoapOut">
+        <wsdl:part name="parameters" element="tns:LoginResponse" />
+    </wsdl:message>
+    <wsdl:message name="LoginRegistrantForPostSoapIn">
+        <wsdl:part name="parameters" element="tns:LoginRegistrantForPost" />
+    </wsdl:message>
+    <wsdl:message name="LoginRegistrantForPostSoapOut">
+        <wsdl:part name="parameters" element="tns:LoginRegistrantForPostResponse" />
+    </wsdl:message>
+    <wsdl:message name="LoginRegistrantSoapIn">
+        <wsdl:part name="parameters" element="tns:LoginRegistrant" />
+    </wsdl:message>
+    <wsdl:message name="LoginRegistrantSoapOut">
+        <wsdl:part name="parameters" element="tns:LoginRegistrantResponse" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginSoapIn">
+        <wsdl:part name="parameters" element="tns:_GuestLogin" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginSoapOut">
+        <wsdl:part name="parameters" element="tns:_GuestLoginResponse" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginForPostSoapIn">
+        <wsdl:part name="parameters" element="tns:_GuestLoginForPost" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginForPostSoapOut">
+        <wsdl:part name="parameters" element="tns:_GuestLoginForPostResponse" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyGuestLoginSoapIn">
+        <wsdl:part name="parameters" element="tns:_VerifyGuestLogin" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyGuestLoginSoapOut">
+        <wsdl:part name="parameters" element="tns:_VerifyGuestLoginResponse" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyGuestLoginForPostSoapIn">
+        <wsdl:part name="parameters" element="tns:_VerifyGuestLoginForPost" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyGuestLoginForPostSoapOut">
+        <wsdl:part name="parameters" element="tns:_VerifyGuestLoginForPostResponse" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyPasswordRequiredToAccessSoapIn">
+        <wsdl:part name="parameters" element="tns:_VerifyPasswordRequiredToAccess" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyPasswordRequiredToAccessSoapOut">
+        <wsdl:part name="parameters" element="tns:_VerifyPasswordRequiredToAccessResponse" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyPasswordRequiredToAccessForPostSoapIn">
+        <wsdl:part name="parameters" element="tns:_VerifyPasswordRequiredToAccessForPost" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyPasswordRequiredToAccessForPostSoapOut">
+        <wsdl:part name="parameters" element="tns:_VerifyPasswordRequiredToAccessForPostResponse" />
+    </wsdl:message>
+    <wsdl:message name="CopyEventSoapIn">
+        <wsdl:part name="parameters" element="tns:CopyEvent" />
+    </wsdl:message>
+    <wsdl:message name="CopyEventSoapOut">
+        <wsdl:part name="parameters" element="tns:CopyEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="CopyEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetEventsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetEvents" />
+    </wsdl:message>
+    <wsdl:message name="GetEventsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetEventsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetEventsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetPublicEventsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetPublicEvents" />
+    </wsdl:message>
+    <wsdl:message name="GetPublicEventsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetPublicEventsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetPublicEventsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetEventSoapIn">
+        <wsdl:part name="parameters" element="tns:GetEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventSoapOut">
+        <wsdl:part name="parameters" element="tns:GetEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="_GetEventForUserSoapIn">
+        <wsdl:part name="parameters" element="tns:_GetEventForUser" />
+    </wsdl:message>
+    <wsdl:message name="_GetEventForUserSoapOut">
+        <wsdl:part name="parameters" element="tns:_GetEventForUserResponse" />
+    </wsdl:message>
+    <wsdl:message name="_GetEventForUserTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetSurveysForEventSoapIn">
+        <wsdl:part name="parameters" element="tns:GetSurveysForEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetSurveysForEventSoapOut">
+        <wsdl:part name="parameters" element="tns:GetSurveysForEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetSurveysForEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetEventStatisticsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetEventStatistics" />
+    </wsdl:message>
+    <wsdl:message name="GetEventStatisticsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetEventStatisticsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetEventStatisticsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetEventWebsiteSoapIn">
+        <wsdl:part name="parameters" element="tns:GetEventWebsite" />
+    </wsdl:message>
+    <wsdl:message name="GetEventWebsiteSoapOut">
+        <wsdl:part name="parameters" element="tns:GetEventWebsiteResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetEventWebsiteTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForCustomFieldSoapIn">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsForCustomField" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForCustomFieldSoapOut">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsForCustomFieldResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForCustomFieldTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForAgendaSoapIn">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsForAgenda" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForAgendaSoapOut">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsForAgendaResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForAgendaTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationSoapIn">
+        <wsdl:part name="parameters" element="tns:GetRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationSoapOut">
+        <wsdl:part name="parameters" element="tns:GetRegistrationResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForEventSoapIn">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsForEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForEventSoapOut">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsForEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsMerchandiseForEventSoapIn">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsMerchandiseForEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsMerchandiseForEventSoapOut">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsMerchandiseForEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsMerchandiseForEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetRegistrations" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetRegistrationsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetIncompleteRegistrations" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetIncompleteRegistrationsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsForEventSoapIn">
+        <wsdl:part name="parameters" element="tns:GetIncompleteRegistrationsForEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsForEventSoapOut">
+        <wsdl:part name="parameters" element="tns:GetIncompleteRegistrationsForEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsForEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="ContactEventOrganizerSoapIn">
+        <wsdl:part name="parameters" element="tns:ContactEventOrganizer" />
+    </wsdl:message>
+    <wsdl:message name="ContactEventOrganizerSoapOut">
+        <wsdl:part name="parameters" element="tns:ContactEventOrganizerResponse" />
+    </wsdl:message>
+    <wsdl:message name="ContactEventOrganizerTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetTransactions" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetTransactionsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionSoapIn">
+        <wsdl:part name="parameters" element="tns:GetTransaction" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionSoapOut">
+        <wsdl:part name="parameters" element="tns:GetTransactionResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsForEventSoapIn">
+        <wsdl:part name="parameters" element="tns:GetTransactionsForEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsForEventSoapOut">
+        <wsdl:part name="parameters" element="tns:GetTransactionsForEventResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsForEventTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetCustomFields" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetAgendaItems" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetAgendaItemsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldListItemsSoapIn">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldListItems" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldListItemsSoapOut">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldListItemsResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldListItemsTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsForRegistrationSoapIn">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldsForRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsForRegistrationSoapOut">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldsForRegistrationResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsForRegistrationTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsForRegistrationSoapIn">
+        <wsdl:part name="parameters" element="tns:GetAgendaItemsForRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsForRegistrationSoapOut">
+        <wsdl:part name="parameters" element="tns:GetAgendaItemsForRegistrationResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsForRegistrationTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemResponsesForRegistrationSoapIn">
+        <wsdl:part name="parameters" element="tns:GetAgendaItemResponsesForRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemResponsesForRegistrationSoapOut">
+        <wsdl:part name="parameters" element="tns:GetAgendaItemResponsesForRegistrationResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemResponsesForRegistrationTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="UpdateAgendaItemResponsesForRegistrationSoapIn">
+        <wsdl:part name="parameters" element="tns:UpdateAgendaItemResponsesForRegistration" />
+    </wsdl:message>
+    <wsdl:message name="UpdateAgendaItemResponsesForRegistrationSoapOut">
+        <wsdl:part name="parameters" element="tns:UpdateAgendaItemResponsesForRegistrationResponse" />
+    </wsdl:message>
+    <wsdl:message name="UpdateAgendaItemResponsesForRegistrationTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesSoapIn">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldResponses" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesSoapOut">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldResponsesResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesForRegistrationSoapIn">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldResponsesForRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesForRegistrationSoapOut">
+        <wsdl:part name="parameters" element="tns:GetCustomFieldResponsesForRegistrationResponse" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesForRegistrationTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="UpdateCustomFieldResponsesForRegistrationSoapIn">
+        <wsdl:part name="parameters" element="tns:UpdateCustomFieldResponsesForRegistration" />
+    </wsdl:message>
+    <wsdl:message name="UpdateCustomFieldResponsesForRegistrationSoapOut">
+        <wsdl:part name="parameters" element="tns:UpdateCustomFieldResponsesForRegistrationResponse" />
+    </wsdl:message>
+    <wsdl:message name="UpdateCustomFieldResponsesForRegistrationTokenHeader">
+        <wsdl:part name="TokenHeader" element="tns:TokenHeader" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForEventHttpGetIn">
+        <wsdl:part name="registrationIDs" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForEventHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfBoolean" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForAgendaItemHttpGetIn">
+        <wsdl:part name="registrationIDs" type="s:string" />
+        <wsdl:part name="agendaItemID" type="s:string" />
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForAgendaItemHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfBoolean" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsForEventHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsForEventHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomReport" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsHttpGetIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomReport" />
+    </wsdl:message>
+    <wsdl:message name="_GetAttendeeMobileAppSettingsHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="accessCode" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_GetAttendeeMobileAppSettingsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfAttendeeMobileAppSettings" />
+    </wsdl:message>
+    <wsdl:message name="_GetOrganizerMobileAppSettingsHttpGetIn" />
+    <wsdl:message name="_GetOrganizerMobileAppSettingsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfOrganizerMobileAppSettings" />
+    </wsdl:message>
+    <wsdl:message name="ValidateSFUserHttpGetIn">
+        <wsdl:part name="userId" type="s:string" />
+        <wsdl:part name="token" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="ValidateSFUserHttpGetOut">
+        <wsdl:part name="Body" element="tns:int" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsByEventIDHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsByEventIDHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="LoginHttpGetIn">
+        <wsdl:part name="username" type="s:string" />
+        <wsdl:part name="password" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="LoginHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfLoginResults" />
+    </wsdl:message>
+    <wsdl:message name="LoginRegistrantForPostHttpGetIn" />
+    <wsdl:message name="LoginRegistrantForPostHttpGetOut" />
+    <wsdl:message name="LoginRegistrantHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="email" type="s:string" />
+        <wsdl:part name="password" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="LoginRegistrantHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="email" type="s:string" />
+        <wsdl:part name="password" type="s:string" />
+        <wsdl:part name="glpk" type="s:string" />
+        <wsdl:part name="rie" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginForPostHttpGetIn" />
+    <wsdl:message name="_GuestLoginForPostHttpGetOut" />
+    <wsdl:message name="_VerifyGuestLoginHttpGetIn">
+        <wsdl:part name="eventId" type="s:string" />
+        <wsdl:part name="email" type="s:string" />
+        <wsdl:part name="glpk" type="s:string" />
+        <wsdl:part name="rie" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyGuestLoginHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfVerifyGuestLoginResult" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyGuestLoginForPostHttpGetIn" />
+    <wsdl:message name="_VerifyGuestLoginForPostHttpGetOut" />
+    <wsdl:message name="_VerifyPasswordRequiredToAccessHttpGetIn">
+        <wsdl:part name="eventId" type="s:string" />
+        <wsdl:part name="email" type="s:string" />
+        <wsdl:part name="glpk" type="s:string" />
+        <wsdl:part name="rie" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyPasswordRequiredToAccessHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfVerifyPasswordRequiredResult" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyPasswordRequiredToAccessForPostHttpGetIn" />
+    <wsdl:message name="_VerifyPasswordRequiredToAccessForPostHttpGetOut" />
+    <wsdl:message name="CopyEventHttpGetIn">
+        <wsdl:part name="eventId" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="CopyEventHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventsHttpGetIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetEventsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetPublicEventsHttpGetIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetPublicEventsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetEventHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="_GetEventForUserHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_GetEventForUserHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventStatisticsHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetEventStatisticsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventWebsiteHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetEventWebsiteHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEventWebsite" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForCustomFieldHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="cfid" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForCustomFieldHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForAgendaHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="cfid" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForAgendaHttpGetOut">
+        <wsdl:part name="Body" element="tns:ArrayOfAPIRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationHttpGetIn">
+        <wsdl:part name="registrationID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForEventHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForEventHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsMerchandiseForEventHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsMerchandiseForEventHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistrationWithMerchandise" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsHttpGetIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsHttpGetIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsForEventHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsForEventHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsHttpGetIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfTransaction" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionHttpGetIn">
+        <wsdl:part name="ID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfTransaction" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsForEventHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsForEventHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfTransaction" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="pageSectionID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomField" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomField" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldListItemsHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="cfID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldListItemsHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomFieldListItem" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesHttpGetIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="cfID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesHttpGetOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomFieldResponse" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForEventHttpPostIn">
+        <wsdl:part name="registrationIDs" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForEventHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfBoolean" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForAgendaItemHttpPostIn">
+        <wsdl:part name="registrationIDs" type="s:string" />
+        <wsdl:part name="agendaItemID" type="s:string" />
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="CheckinRegistrationsForAgendaItemHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfBoolean" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsForEventHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsForEventHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomReport" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsHttpPostIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomReportsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomReport" />
+    </wsdl:message>
+    <wsdl:message name="_GetAttendeeMobileAppSettingsHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="accessCode" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_GetAttendeeMobileAppSettingsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfAttendeeMobileAppSettings" />
+    </wsdl:message>
+    <wsdl:message name="_GetOrganizerMobileAppSettingsHttpPostIn" />
+    <wsdl:message name="_GetOrganizerMobileAppSettingsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfOrganizerMobileAppSettings" />
+    </wsdl:message>
+    <wsdl:message name="ValidateSFUserHttpPostIn">
+        <wsdl:part name="userId" type="s:string" />
+        <wsdl:part name="token" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="ValidateSFUserHttpPostOut">
+        <wsdl:part name="Body" element="tns:int" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsByEventIDHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsByEventIDHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="LoginHttpPostIn">
+        <wsdl:part name="username" type="s:string" />
+        <wsdl:part name="password" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="LoginHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfLoginResults" />
+    </wsdl:message>
+    <wsdl:message name="LoginRegistrantForPostHttpPostIn" />
+    <wsdl:message name="LoginRegistrantForPostHttpPostOut" />
+    <wsdl:message name="LoginRegistrantHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="email" type="s:string" />
+        <wsdl:part name="password" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="LoginRegistrantHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="email" type="s:string" />
+        <wsdl:part name="password" type="s:string" />
+        <wsdl:part name="glpk" type="s:string" />
+        <wsdl:part name="rie" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="_GuestLoginForPostHttpPostIn" />
+    <wsdl:message name="_GuestLoginForPostHttpPostOut" />
+    <wsdl:message name="_VerifyGuestLoginHttpPostIn">
+        <wsdl:part name="eventId" type="s:string" />
+        <wsdl:part name="email" type="s:string" />
+        <wsdl:part name="glpk" type="s:string" />
+        <wsdl:part name="rie" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyGuestLoginHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfVerifyGuestLoginResult" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyGuestLoginForPostHttpPostIn" />
+    <wsdl:message name="_VerifyGuestLoginForPostHttpPostOut" />
+    <wsdl:message name="_VerifyPasswordRequiredToAccessHttpPostIn">
+        <wsdl:part name="eventId" type="s:string" />
+        <wsdl:part name="email" type="s:string" />
+        <wsdl:part name="glpk" type="s:string" />
+        <wsdl:part name="rie" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyPasswordRequiredToAccessHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfVerifyPasswordRequiredResult" />
+    </wsdl:message>
+    <wsdl:message name="_VerifyPasswordRequiredToAccessForPostHttpPostIn" />
+    <wsdl:message name="_VerifyPasswordRequiredToAccessForPostHttpPostOut" />
+    <wsdl:message name="CopyEventHttpPostIn">
+        <wsdl:part name="eventId" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="CopyEventHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventsHttpPostIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetEventsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetPublicEventsHttpPostIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetPublicEventsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetEventHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="_GetEventForUserHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="_GetEventForUserHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventStatisticsHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetEventStatisticsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEvent" />
+    </wsdl:message>
+    <wsdl:message name="GetEventWebsiteHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetEventWebsiteHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfEventWebsite" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForCustomFieldHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="cfid" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForCustomFieldHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForAgendaHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="cfid" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForAgendaHttpPostOut">
+        <wsdl:part name="Body" element="tns:ArrayOfAPIRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationHttpPostIn">
+        <wsdl:part name="registrationID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForEventHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsForEventHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsMerchandiseForEventHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsMerchandiseForEventHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistrationWithMerchandise" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsHttpPostIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetRegistrationsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsHttpPostIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsForEventHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetIncompleteRegistrationsForEventHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfRegistration" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsHttpPostIn">
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfTransaction" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionHttpPostIn">
+        <wsdl:part name="ID" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfTransaction" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsForEventHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetTransactionsForEventHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfTransaction" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="pageSectionID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomField" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetAgendaItemsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomField" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldListItemsHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="cfID" type="s:string" />
+        <wsdl:part name="filter" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldListItemsHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomFieldListItem" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesHttpPostIn">
+        <wsdl:part name="eventID" type="s:string" />
+        <wsdl:part name="cfID" type="s:string" />
+        <wsdl:part name="orderBy" type="s:string" />
+    </wsdl:message>
+    <wsdl:message name="GetCustomFieldResponsesHttpPostOut">
+        <wsdl:part name="Body" element="tns:ResultsOfListOfCustomFieldResponse" />
+    </wsdl:message>
+    <wsdl:portType name="RegOnline_x0020_APISoap">
+        <wsdl:operation name="CheckinRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Checks in selected registrations</wsdl:documentation>
+            <wsdl:input message="tns:CheckinRegistrationsForEventSoapIn" />
+            <wsdl:output message="tns:CheckinRegistrationsForEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="CheckinRegistrationsForAgendaItem">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Checks in selected attendees</wsdl:documentation>
+            <wsdl:input message="tns:CheckinRegistrationsForAgendaItemSoapIn" />
+            <wsdl:output message="tns:CheckinRegistrationsForAgendaItemSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="UpdateRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Updates the standard fields of a registration</wsdl:documentation>
+            <wsdl:input message="tns:UpdateRegistrationSoapIn" />
+            <wsdl:output message="tns:UpdateRegistrationSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReportsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets CustomReports By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomReportsForEventSoapIn" />
+            <wsdl:output message="tns:GetCustomReportsForEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReports">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets CustomReports</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomReportsSoapIn" />
+            <wsdl:output message="tns:GetCustomReportsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetDirectories">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets public directories</wsdl:documentation>
+            <wsdl:input message="tns:GetDirectoriesSoapIn" />
+            <wsdl:output message="tns:GetDirectoriesSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetDirectory">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets attendees in the directory</wsdl:documentation>
+            <wsdl:input message="tns:GetDirectorySoapIn" />
+            <wsdl:output message="tns:GetDirectorySoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetAttendeeMobileAppSettings">
+            <wsdl:input message="tns:_GetAttendeeMobileAppSettingsSoapIn" />
+            <wsdl:output message="tns:_GetAttendeeMobileAppSettingsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetOrganizerMobileAppSettings">
+            <wsdl:input message="tns:_GetOrganizerMobileAppSettingsSoapIn" />
+            <wsdl:output message="tns:_GetOrganizerMobileAppSettingsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="ValidateSFUser">
+            <wsdl:input message="tns:ValidateSFUserSoapIn" />
+            <wsdl:output message="tns:ValidateSFUserSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="UpdateEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Updates event</wsdl:documentation>
+            <wsdl:input message="tns:UpdateEventSoapIn" />
+            <wsdl:output message="tns:UpdateEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsByEventID">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsByEventIDSoapIn" />
+            <wsdl:output message="tns:GetRegistrationsByEventIDSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Login">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login via username and password</wsdl:documentation>
+            <wsdl:input message="tns:LoginSoapIn" />
+            <wsdl:output message="tns:LoginSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrantForPost">
+            <wsdl:input message="tns:LoginRegistrantForPostSoapIn" />
+            <wsdl:output message="tns:LoginRegistrantForPostSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrant">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login a registrant for an event</wsdl:documentation>
+            <wsdl:input message="tns:LoginRegistrantSoapIn" />
+            <wsdl:output message="tns:LoginRegistrantSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLogin">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login a registrant for an event</wsdl:documentation>
+            <wsdl:input message="tns:_GuestLoginSoapIn" />
+            <wsdl:output message="tns:_GuestLoginSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLoginForPost">
+            <wsdl:input message="tns:_GuestLoginForPostSoapIn" />
+            <wsdl:output message="tns:_GuestLoginForPostSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLogin">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a login is a guest one.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyGuestLoginSoapIn" />
+            <wsdl:output message="tns:_VerifyGuestLoginSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLoginForPost">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a login is a guest one for a JSONP HTTP post request.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyGuestLoginForPostSoapIn" />
+            <wsdl:output message="tns:_VerifyGuestLoginForPostSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccess">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a password is required to access.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyPasswordRequiredToAccessSoapIn" />
+            <wsdl:output message="tns:_VerifyPasswordRequiredToAccessSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccessForPost">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a password is required to access (due to guest login and password disabled in account level) for a JSONP HTTP post request.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyPasswordRequiredToAccessForPostSoapIn" />
+            <wsdl:output message="tns:_VerifyPasswordRequiredToAccessForPostSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="CopyEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Copy Event</wsdl:documentation>
+            <wsdl:input message="tns:CopyEventSoapIn" />
+            <wsdl:output message="tns:CopyEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEvents">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Events</wsdl:documentation>
+            <wsdl:input message="tns:GetEventsSoapIn" />
+            <wsdl:output message="tns:GetEventsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetPublicEvents">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns events that are active, future (but &lt; x days) and marked to be publicized.</wsdl:documentation>
+            <wsdl:input message="tns:GetPublicEventsSoapIn" />
+            <wsdl:output message="tns:GetPublicEventsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns a single event based on the Event ID</wsdl:documentation>
+            <wsdl:input message="tns:GetEventSoapIn" />
+            <wsdl:output message="tns:GetEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetEventForUser">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns a single event based on the Event ID and user</wsdl:documentation>
+            <wsdl:input message="tns:_GetEventForUserSoapIn" />
+            <wsdl:output message="tns:_GetEventForUserSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetSurveysForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns surveys associated with the given event.</wsdl:documentation>
+            <wsdl:input message="tns:GetSurveysForEventSoapIn" />
+            <wsdl:output message="tns:GetSurveysForEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEventStatistics">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event details for dashboard</wsdl:documentation>
+            <wsdl:input message="tns:GetEventStatisticsSoapIn" />
+            <wsdl:output message="tns:GetEventStatisticsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEventWebsite">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event Website for a single event</wsdl:documentation>
+            <wsdl:input message="tns:GetEventWebsiteSoapIn" />
+            <wsdl:output message="tns:GetEventWebsiteSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForCustomField">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForCustomFieldSoapIn" />
+            <wsdl:output message="tns:GetRegistrationsForCustomFieldSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForAgenda">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations by Agenda item</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForAgendaSoapIn" />
+            <wsdl:output message="tns:GetRegistrationsForAgendaSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets a Registration by ID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationSoapIn" />
+            <wsdl:output message="tns:GetRegistrationSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForEventSoapIn" />
+            <wsdl:output message="tns:GetRegistrationsForEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsMerchandiseForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID, embed merchandise purchases</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsMerchandiseForEventSoapIn" />
+            <wsdl:output message="tns:GetRegistrationsMerchandiseForEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrations">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsSoapIn" />
+            <wsdl:output message="tns:GetRegistrationsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrations">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Incomplete Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetIncompleteRegistrationsSoapIn" />
+            <wsdl:output message="tns:GetIncompleteRegistrationsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Incomplete Registrations By Event ID</wsdl:documentation>
+            <wsdl:input message="tns:GetIncompleteRegistrationsForEventSoapIn" />
+            <wsdl:output message="tns:GetIncompleteRegistrationsForEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="ContactEventOrganizer">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Send an Email to Event Organizer</wsdl:documentation>
+            <wsdl:input message="tns:ContactEventOrganizerSoapIn" />
+            <wsdl:output message="tns:ContactEventOrganizerSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactions">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Transactions</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionsSoapIn" />
+            <wsdl:output message="tns:GetTransactionsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransaction">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets a transaction by its ID</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionSoapIn" />
+            <wsdl:output message="tns:GetTransactionSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactionsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets all transactions for an event</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionsForEventSoapIn" />
+            <wsdl:output message="tns:GetTransactionsForEventSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFields">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Custom Fields for Event and Location</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldsSoapIn" />
+            <wsdl:output message="tns:GetCustomFieldsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItems">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event Schedule</wsdl:documentation>
+            <wsdl:input message="tns:GetAgendaItemsSoapIn" />
+            <wsdl:output message="tns:GetAgendaItemsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldListItems">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets the list items for a multiple choice Custom Field</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldListItemsSoapIn" />
+            <wsdl:output message="tns:GetCustomFieldListItemsSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldsForRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Get a list of all custom fields available to the given registration and location</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldsForRegistrationSoapIn" />
+            <wsdl:output message="tns:GetCustomFieldsForRegistrationSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItemsForRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets a list of all agenda items available to the given registration and location</wsdl:documentation>
+            <wsdl:input message="tns:GetAgendaItemsForRegistrationSoapIn" />
+            <wsdl:output message="tns:GetAgendaItemsForRegistrationSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItemResponsesForRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Attendee's Schedule</wsdl:documentation>
+            <wsdl:input message="tns:GetAgendaItemResponsesForRegistrationSoapIn" />
+            <wsdl:output message="tns:GetAgendaItemResponsesForRegistrationSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="UpdateAgendaItemResponsesForRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Updates the agenda item responses of registration</wsdl:documentation>
+            <wsdl:input message="tns:UpdateAgendaItemResponsesForRegistrationSoapIn" />
+            <wsdl:output message="tns:UpdateAgendaItemResponsesForRegistrationSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponses">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets all responses for an agenda item</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldResponsesSoapIn" />
+            <wsdl:output message="tns:GetCustomFieldResponsesSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponsesForRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets custom field responses for a registration</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldResponsesForRegistrationSoapIn" />
+            <wsdl:output message="tns:GetCustomFieldResponsesForRegistrationSoapOut" />
+        </wsdl:operation>
+        <wsdl:operation name="UpdateCustomFieldResponsesForRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Updates the custom fields of registrations</wsdl:documentation>
+            <wsdl:input message="tns:UpdateCustomFieldResponsesForRegistrationSoapIn" />
+            <wsdl:output message="tns:UpdateCustomFieldResponsesForRegistrationSoapOut" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:portType name="RegOnline_x0020_APIHttpGet">
+        <wsdl:operation name="CheckinRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Checks in selected registrations</wsdl:documentation>
+            <wsdl:input message="tns:CheckinRegistrationsForEventHttpGetIn" />
+            <wsdl:output message="tns:CheckinRegistrationsForEventHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="CheckinRegistrationsForAgendaItem">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Checks in selected attendees</wsdl:documentation>
+            <wsdl:input message="tns:CheckinRegistrationsForAgendaItemHttpGetIn" />
+            <wsdl:output message="tns:CheckinRegistrationsForAgendaItemHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReportsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets CustomReports By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomReportsForEventHttpGetIn" />
+            <wsdl:output message="tns:GetCustomReportsForEventHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReports">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets CustomReports</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomReportsHttpGetIn" />
+            <wsdl:output message="tns:GetCustomReportsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetAttendeeMobileAppSettings">
+            <wsdl:input message="tns:_GetAttendeeMobileAppSettingsHttpGetIn" />
+            <wsdl:output message="tns:_GetAttendeeMobileAppSettingsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetOrganizerMobileAppSettings">
+            <wsdl:input message="tns:_GetOrganizerMobileAppSettingsHttpGetIn" />
+            <wsdl:output message="tns:_GetOrganizerMobileAppSettingsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="ValidateSFUser">
+            <wsdl:input message="tns:ValidateSFUserHttpGetIn" />
+            <wsdl:output message="tns:ValidateSFUserHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsByEventID">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsByEventIDHttpGetIn" />
+            <wsdl:output message="tns:GetRegistrationsByEventIDHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Login">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login via username and password</wsdl:documentation>
+            <wsdl:input message="tns:LoginHttpGetIn" />
+            <wsdl:output message="tns:LoginHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrantForPost">
+            <wsdl:input message="tns:LoginRegistrantForPostHttpGetIn" />
+            <wsdl:output message="tns:LoginRegistrantForPostHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrant">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login a registrant for an event</wsdl:documentation>
+            <wsdl:input message="tns:LoginRegistrantHttpGetIn" />
+            <wsdl:output message="tns:LoginRegistrantHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLogin">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login a registrant for an event</wsdl:documentation>
+            <wsdl:input message="tns:_GuestLoginHttpGetIn" />
+            <wsdl:output message="tns:_GuestLoginHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLoginForPost">
+            <wsdl:input message="tns:_GuestLoginForPostHttpGetIn" />
+            <wsdl:output message="tns:_GuestLoginForPostHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLogin">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a login is a guest one.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyGuestLoginHttpGetIn" />
+            <wsdl:output message="tns:_VerifyGuestLoginHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLoginForPost">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a login is a guest one for a JSONP HTTP post request.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyGuestLoginForPostHttpGetIn" />
+            <wsdl:output message="tns:_VerifyGuestLoginForPostHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccess">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a password is required to access.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyPasswordRequiredToAccessHttpGetIn" />
+            <wsdl:output message="tns:_VerifyPasswordRequiredToAccessHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccessForPost">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a password is required to access (due to guest login and password disabled in account level) for a JSONP HTTP post request.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyPasswordRequiredToAccessForPostHttpGetIn" />
+            <wsdl:output message="tns:_VerifyPasswordRequiredToAccessForPostHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="CopyEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Copy Event</wsdl:documentation>
+            <wsdl:input message="tns:CopyEventHttpGetIn" />
+            <wsdl:output message="tns:CopyEventHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEvents">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Events</wsdl:documentation>
+            <wsdl:input message="tns:GetEventsHttpGetIn" />
+            <wsdl:output message="tns:GetEventsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetPublicEvents">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns events that are active, future (but &lt; x days) and marked to be publicized.</wsdl:documentation>
+            <wsdl:input message="tns:GetPublicEventsHttpGetIn" />
+            <wsdl:output message="tns:GetPublicEventsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns a single event based on the Event ID</wsdl:documentation>
+            <wsdl:input message="tns:GetEventHttpGetIn" />
+            <wsdl:output message="tns:GetEventHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetEventForUser">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns a single event based on the Event ID and user</wsdl:documentation>
+            <wsdl:input message="tns:_GetEventForUserHttpGetIn" />
+            <wsdl:output message="tns:_GetEventForUserHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEventStatistics">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event details for dashboard</wsdl:documentation>
+            <wsdl:input message="tns:GetEventStatisticsHttpGetIn" />
+            <wsdl:output message="tns:GetEventStatisticsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEventWebsite">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event Website for a single event</wsdl:documentation>
+            <wsdl:input message="tns:GetEventWebsiteHttpGetIn" />
+            <wsdl:output message="tns:GetEventWebsiteHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForCustomField">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForCustomFieldHttpGetIn" />
+            <wsdl:output message="tns:GetRegistrationsForCustomFieldHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForAgenda">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations by Agenda item</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForAgendaHttpGetIn" />
+            <wsdl:output message="tns:GetRegistrationsForAgendaHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets a Registration by ID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationHttpGetIn" />
+            <wsdl:output message="tns:GetRegistrationHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForEventHttpGetIn" />
+            <wsdl:output message="tns:GetRegistrationsForEventHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsMerchandiseForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID, embed merchandise purchases</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsMerchandiseForEventHttpGetIn" />
+            <wsdl:output message="tns:GetRegistrationsMerchandiseForEventHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrations">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsHttpGetIn" />
+            <wsdl:output message="tns:GetRegistrationsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrations">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Incomplete Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetIncompleteRegistrationsHttpGetIn" />
+            <wsdl:output message="tns:GetIncompleteRegistrationsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Incomplete Registrations By Event ID</wsdl:documentation>
+            <wsdl:input message="tns:GetIncompleteRegistrationsForEventHttpGetIn" />
+            <wsdl:output message="tns:GetIncompleteRegistrationsForEventHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactions">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Transactions</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionsHttpGetIn" />
+            <wsdl:output message="tns:GetTransactionsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransaction">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets a transaction by its ID</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionHttpGetIn" />
+            <wsdl:output message="tns:GetTransactionHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactionsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets all transactions for an event</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionsForEventHttpGetIn" />
+            <wsdl:output message="tns:GetTransactionsForEventHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFields">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Custom Fields for Event and Location</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldsHttpGetIn" />
+            <wsdl:output message="tns:GetCustomFieldsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItems">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event Schedule</wsdl:documentation>
+            <wsdl:input message="tns:GetAgendaItemsHttpGetIn" />
+            <wsdl:output message="tns:GetAgendaItemsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldListItems">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets the list items for a multiple choice Custom Field</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldListItemsHttpGetIn" />
+            <wsdl:output message="tns:GetCustomFieldListItemsHttpGetOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponses">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets all responses for an agenda item</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldResponsesHttpGetIn" />
+            <wsdl:output message="tns:GetCustomFieldResponsesHttpGetOut" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:portType name="RegOnline_x0020_APIHttpPost">
+        <wsdl:operation name="CheckinRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Checks in selected registrations</wsdl:documentation>
+            <wsdl:input message="tns:CheckinRegistrationsForEventHttpPostIn" />
+            <wsdl:output message="tns:CheckinRegistrationsForEventHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="CheckinRegistrationsForAgendaItem">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Checks in selected attendees</wsdl:documentation>
+            <wsdl:input message="tns:CheckinRegistrationsForAgendaItemHttpPostIn" />
+            <wsdl:output message="tns:CheckinRegistrationsForAgendaItemHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReportsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets CustomReports By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomReportsForEventHttpPostIn" />
+            <wsdl:output message="tns:GetCustomReportsForEventHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReports">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets CustomReports</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomReportsHttpPostIn" />
+            <wsdl:output message="tns:GetCustomReportsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetAttendeeMobileAppSettings">
+            <wsdl:input message="tns:_GetAttendeeMobileAppSettingsHttpPostIn" />
+            <wsdl:output message="tns:_GetAttendeeMobileAppSettingsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetOrganizerMobileAppSettings">
+            <wsdl:input message="tns:_GetOrganizerMobileAppSettingsHttpPostIn" />
+            <wsdl:output message="tns:_GetOrganizerMobileAppSettingsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="ValidateSFUser">
+            <wsdl:input message="tns:ValidateSFUserHttpPostIn" />
+            <wsdl:output message="tns:ValidateSFUserHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsByEventID">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsByEventIDHttpPostIn" />
+            <wsdl:output message="tns:GetRegistrationsByEventIDHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="Login">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login via username and password</wsdl:documentation>
+            <wsdl:input message="tns:LoginHttpPostIn" />
+            <wsdl:output message="tns:LoginHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrantForPost">
+            <wsdl:input message="tns:LoginRegistrantForPostHttpPostIn" />
+            <wsdl:output message="tns:LoginRegistrantForPostHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrant">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login a registrant for an event</wsdl:documentation>
+            <wsdl:input message="tns:LoginRegistrantHttpPostIn" />
+            <wsdl:output message="tns:LoginRegistrantHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLogin">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Login a registrant for an event</wsdl:documentation>
+            <wsdl:input message="tns:_GuestLoginHttpPostIn" />
+            <wsdl:output message="tns:_GuestLoginHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLoginForPost">
+            <wsdl:input message="tns:_GuestLoginForPostHttpPostIn" />
+            <wsdl:output message="tns:_GuestLoginForPostHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLogin">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a login is a guest one.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyGuestLoginHttpPostIn" />
+            <wsdl:output message="tns:_VerifyGuestLoginHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLoginForPost">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a login is a guest one for a JSONP HTTP post request.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyGuestLoginForPostHttpPostIn" />
+            <wsdl:output message="tns:_VerifyGuestLoginForPostHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccess">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a password is required to access.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyPasswordRequiredToAccessHttpPostIn" />
+            <wsdl:output message="tns:_VerifyPasswordRequiredToAccessHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccessForPost">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Verifies if a password is required to access (due to guest login and password disabled in account level) for a JSONP HTTP post request.</wsdl:documentation>
+            <wsdl:input message="tns:_VerifyPasswordRequiredToAccessForPostHttpPostIn" />
+            <wsdl:output message="tns:_VerifyPasswordRequiredToAccessForPostHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="CopyEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Copy Event</wsdl:documentation>
+            <wsdl:input message="tns:CopyEventHttpPostIn" />
+            <wsdl:output message="tns:CopyEventHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEvents">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Events</wsdl:documentation>
+            <wsdl:input message="tns:GetEventsHttpPostIn" />
+            <wsdl:output message="tns:GetEventsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetPublicEvents">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns events that are active, future (but &lt; x days) and marked to be publicized.</wsdl:documentation>
+            <wsdl:input message="tns:GetPublicEventsHttpPostIn" />
+            <wsdl:output message="tns:GetPublicEventsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns a single event based on the Event ID</wsdl:documentation>
+            <wsdl:input message="tns:GetEventHttpPostIn" />
+            <wsdl:output message="tns:GetEventHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="_GetEventForUser">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Returns a single event based on the Event ID and user</wsdl:documentation>
+            <wsdl:input message="tns:_GetEventForUserHttpPostIn" />
+            <wsdl:output message="tns:_GetEventForUserHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEventStatistics">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event details for dashboard</wsdl:documentation>
+            <wsdl:input message="tns:GetEventStatisticsHttpPostIn" />
+            <wsdl:output message="tns:GetEventStatisticsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetEventWebsite">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event Website for a single event</wsdl:documentation>
+            <wsdl:input message="tns:GetEventWebsiteHttpPostIn" />
+            <wsdl:output message="tns:GetEventWebsiteHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForCustomField">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForCustomFieldHttpPostIn" />
+            <wsdl:output message="tns:GetRegistrationsForCustomFieldHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForAgenda">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations by Agenda item</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForAgendaHttpPostIn" />
+            <wsdl:output message="tns:GetRegistrationsForAgendaHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistration">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets a Registration by ID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationHttpPostIn" />
+            <wsdl:output message="tns:GetRegistrationHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsForEventHttpPostIn" />
+            <wsdl:output message="tns:GetRegistrationsForEventHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsMerchandiseForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations By EventID, embed merchandise purchases</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsMerchandiseForEventHttpPostIn" />
+            <wsdl:output message="tns:GetRegistrationsMerchandiseForEventHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrations">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetRegistrationsHttpPostIn" />
+            <wsdl:output message="tns:GetRegistrationsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrations">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Incomplete Registrations</wsdl:documentation>
+            <wsdl:input message="tns:GetIncompleteRegistrationsHttpPostIn" />
+            <wsdl:output message="tns:GetIncompleteRegistrationsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrationsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Incomplete Registrations By Event ID</wsdl:documentation>
+            <wsdl:input message="tns:GetIncompleteRegistrationsForEventHttpPostIn" />
+            <wsdl:output message="tns:GetIncompleteRegistrationsForEventHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactions">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Transactions</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionsHttpPostIn" />
+            <wsdl:output message="tns:GetTransactionsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransaction">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets a transaction by its ID</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionHttpPostIn" />
+            <wsdl:output message="tns:GetTransactionHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactionsForEvent">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets all transactions for an event</wsdl:documentation>
+            <wsdl:input message="tns:GetTransactionsForEventHttpPostIn" />
+            <wsdl:output message="tns:GetTransactionsForEventHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFields">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Custom Fields for Event and Location</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldsHttpPostIn" />
+            <wsdl:output message="tns:GetCustomFieldsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItems">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets Event Schedule</wsdl:documentation>
+            <wsdl:input message="tns:GetAgendaItemsHttpPostIn" />
+            <wsdl:output message="tns:GetAgendaItemsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldListItems">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets the list items for a multiple choice Custom Field</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldListItemsHttpPostIn" />
+            <wsdl:output message="tns:GetCustomFieldListItemsHttpPostOut" />
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponses">
+            <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">Gets all responses for an agenda item</wsdl:documentation>
+            <wsdl:input message="tns:GetCustomFieldResponsesHttpPostIn" />
+            <wsdl:output message="tns:GetCustomFieldResponsesHttpPostOut" />
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="RegOnline_x0020_APISoap" type="tns:RegOnline_x0020_APISoap">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="CheckinRegistrationsForEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/CheckinRegistrationsForEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:CheckinRegistrationsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CheckinRegistrationsForAgendaItem">
+            <soap:operation soapAction="http://www.regonline.com/api/CheckinRegistrationsForAgendaItem" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:CheckinRegistrationsForAgendaItemTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="UpdateRegistration">
+            <soap:operation soapAction="http://www.regonline.com/api/UpdateRegistration" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:UpdateRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReportsForEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/GetCustomReportsForEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetCustomReportsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReports">
+            <soap:operation soapAction="http://www.regonline.com/api/GetCustomReports" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetCustomReportsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetDirectories">
+            <soap:operation soapAction="http://www.regonline.com/api/GetDirectories" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetDirectoriesTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetDirectory">
+            <soap:operation soapAction="http://www.regonline.com/api/GetDirectory" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetDirectoryTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetAttendeeMobileAppSettings">
+            <soap:operation soapAction="http://www.regonline.com/api/_GetAttendeeMobileAppSettings" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetOrganizerMobileAppSettings">
+            <soap:operation soapAction="http://www.regonline.com/api/_GetOrganizerMobileAppSettings" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="ValidateSFUser">
+            <soap:operation soapAction="http://www.regonline.com/api/ValidateSFUser" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="UpdateEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/UpdateEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:UpdateEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsByEventID">
+            <soap:operation soapAction="http://www.regonline.com/api/GetRegistrationsByEventID" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetRegistrationsByEventIDTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Login">
+            <soap:operation soapAction="http://www.regonline.com/api/Login" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrantForPost">
+            <soap:operation soapAction="http://www.regonline.com/api/LoginRegistrantForPost" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrant">
+            <soap:operation soapAction="http://www.regonline.com/api/LoginRegistrant" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLogin">
+            <soap:operation soapAction="http://www.regonline.com/api/_GuestLogin" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLoginForPost">
+            <soap:operation soapAction="http://www.regonline.com/api/_GuestLoginForPost" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLogin">
+            <soap:operation soapAction="http://www.regonline.com/api/_VerifyGuestLogin" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLoginForPost">
+            <soap:operation soapAction="http://www.regonline.com/api/_VerifyGuestLoginForPost" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccess">
+            <soap:operation soapAction="http://www.regonline.com/api/_VerifyPasswordRequiredToAccess" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccessForPost">
+            <soap:operation soapAction="http://www.regonline.com/api/_VerifyPasswordRequiredToAccessForPost" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CopyEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/CopyEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:CopyEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEvents">
+            <soap:operation soapAction="http://www.regonline.com/api/GetEvents" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetEventsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetPublicEvents">
+            <soap:operation soapAction="http://www.regonline.com/api/GetPublicEvents" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetPublicEventsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/GetEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetEventForUser">
+            <soap:operation soapAction="http://www.regonline.com/api/_GetEventForUser" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:_GetEventForUserTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetSurveysForEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/GetSurveysForEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetSurveysForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEventStatistics">
+            <soap:operation soapAction="http://www.regonline.com/api/GetEventStatistics" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetEventStatisticsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEventWebsite">
+            <soap:operation soapAction="http://www.regonline.com/api/GetEventWebsite" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetEventWebsiteTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForCustomField">
+            <soap:operation soapAction="http://www.regonline.com/api/GetRegistrationsForCustomField" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetRegistrationsForCustomFieldTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForAgenda">
+            <soap:operation soapAction="http://www.regonline.com/api/GetRegistrationsForAgenda" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetRegistrationsForAgendaTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistration">
+            <soap:operation soapAction="http://www.regonline.com/api/GetRegistration" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/GetRegistrationsForEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetRegistrationsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsMerchandiseForEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/GetRegistrationsMerchandiseForEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetRegistrationsMerchandiseForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrations">
+            <soap:operation soapAction="http://www.regonline.com/api/GetRegistrations" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetRegistrationsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrations">
+            <soap:operation soapAction="http://www.regonline.com/api/GetIncompleteRegistrations" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetIncompleteRegistrationsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrationsForEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/GetIncompleteRegistrationsForEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetIncompleteRegistrationsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="ContactEventOrganizer">
+            <soap:operation soapAction="http://www.regonline.com/api/ContactEventOrganizer" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:ContactEventOrganizerTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactions">
+            <soap:operation soapAction="http://www.regonline.com/api/GetTransactions" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetTransactionsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransaction">
+            <soap:operation soapAction="http://www.regonline.com/api/GetTransaction" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetTransactionTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactionsForEvent">
+            <soap:operation soapAction="http://www.regonline.com/api/GetTransactionsForEvent" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetTransactionsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFields">
+            <soap:operation soapAction="http://www.regonline.com/api/GetCustomFields" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetCustomFieldsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItems">
+            <soap:operation soapAction="http://www.regonline.com/api/GetAgendaItems" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetAgendaItemsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldListItems">
+            <soap:operation soapAction="http://www.regonline.com/api/GetCustomFieldListItems" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetCustomFieldListItemsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldsForRegistration">
+            <soap:operation soapAction="http://www.regonline.com/api/GetCustomFieldsForRegistration" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetCustomFieldsForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItemsForRegistration">
+            <soap:operation soapAction="http://www.regonline.com/api/GetAgendaItemsForRegistration" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetAgendaItemsForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItemResponsesForRegistration">
+            <soap:operation soapAction="http://www.regonline.com/api/GetAgendaItemResponsesForRegistration" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetAgendaItemResponsesForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="UpdateAgendaItemResponsesForRegistration">
+            <soap:operation soapAction="http://www.regonline.com/api/UpdateAgendaItemResponsesForRegistration" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:UpdateAgendaItemResponsesForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponses">
+            <soap:operation soapAction="http://www.regonline.com/api/GetCustomFieldResponses" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetCustomFieldResponsesTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponsesForRegistration">
+            <soap:operation soapAction="http://www.regonline.com/api/GetCustomFieldResponsesForRegistration" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:GetCustomFieldResponsesForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="UpdateCustomFieldResponsesForRegistration">
+            <soap:operation soapAction="http://www.regonline.com/api/UpdateCustomFieldResponsesForRegistration" style="document" />
+            <wsdl:input>
+                <soap:body use="literal" />
+                <soap:header message="tns:UpdateCustomFieldResponsesForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="RegOnline_x0020_APISoap12" type="tns:RegOnline_x0020_APISoap">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+        <wsdl:operation name="CheckinRegistrationsForEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/CheckinRegistrationsForEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:CheckinRegistrationsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CheckinRegistrationsForAgendaItem">
+            <soap12:operation soapAction="http://www.regonline.com/api/CheckinRegistrationsForAgendaItem" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:CheckinRegistrationsForAgendaItemTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="UpdateRegistration">
+            <soap12:operation soapAction="http://www.regonline.com/api/UpdateRegistration" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:UpdateRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReportsForEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetCustomReportsForEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetCustomReportsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReports">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetCustomReports" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetCustomReportsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetDirectories">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetDirectories" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetDirectoriesTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetDirectory">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetDirectory" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetDirectoryTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetAttendeeMobileAppSettings">
+            <soap12:operation soapAction="http://www.regonline.com/api/_GetAttendeeMobileAppSettings" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetOrganizerMobileAppSettings">
+            <soap12:operation soapAction="http://www.regonline.com/api/_GetOrganizerMobileAppSettings" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="ValidateSFUser">
+            <soap12:operation soapAction="http://www.regonline.com/api/ValidateSFUser" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="UpdateEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/UpdateEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:UpdateEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsByEventID">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetRegistrationsByEventID" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetRegistrationsByEventIDTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Login">
+            <soap12:operation soapAction="http://www.regonline.com/api/Login" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrantForPost">
+            <soap12:operation soapAction="http://www.regonline.com/api/LoginRegistrantForPost" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrant">
+            <soap12:operation soapAction="http://www.regonline.com/api/LoginRegistrant" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLogin">
+            <soap12:operation soapAction="http://www.regonline.com/api/_GuestLogin" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLoginForPost">
+            <soap12:operation soapAction="http://www.regonline.com/api/_GuestLoginForPost" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLogin">
+            <soap12:operation soapAction="http://www.regonline.com/api/_VerifyGuestLogin" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLoginForPost">
+            <soap12:operation soapAction="http://www.regonline.com/api/_VerifyGuestLoginForPost" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccess">
+            <soap12:operation soapAction="http://www.regonline.com/api/_VerifyPasswordRequiredToAccess" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccessForPost">
+            <soap12:operation soapAction="http://www.regonline.com/api/_VerifyPasswordRequiredToAccessForPost" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CopyEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/CopyEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:CopyEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEvents">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetEvents" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetEventsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetPublicEvents">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetPublicEvents" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetPublicEventsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetEventForUser">
+            <soap12:operation soapAction="http://www.regonline.com/api/_GetEventForUser" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:_GetEventForUserTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetSurveysForEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetSurveysForEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetSurveysForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEventStatistics">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetEventStatistics" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetEventStatisticsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEventWebsite">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetEventWebsite" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetEventWebsiteTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForCustomField">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetRegistrationsForCustomField" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetRegistrationsForCustomFieldTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForAgenda">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetRegistrationsForAgenda" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetRegistrationsForAgendaTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistration">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetRegistration" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetRegistrationsForEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetRegistrationsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsMerchandiseForEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetRegistrationsMerchandiseForEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetRegistrationsMerchandiseForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrations">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetRegistrations" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetRegistrationsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrations">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetIncompleteRegistrations" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetIncompleteRegistrationsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrationsForEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetIncompleteRegistrationsForEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetIncompleteRegistrationsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="ContactEventOrganizer">
+            <soap12:operation soapAction="http://www.regonline.com/api/ContactEventOrganizer" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:ContactEventOrganizerTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactions">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetTransactions" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetTransactionsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransaction">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetTransaction" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetTransactionTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactionsForEvent">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetTransactionsForEvent" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetTransactionsForEventTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFields">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetCustomFields" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetCustomFieldsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItems">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetAgendaItems" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetAgendaItemsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldListItems">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetCustomFieldListItems" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetCustomFieldListItemsTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldsForRegistration">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetCustomFieldsForRegistration" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetCustomFieldsForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItemsForRegistration">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetAgendaItemsForRegistration" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetAgendaItemsForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItemResponsesForRegistration">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetAgendaItemResponsesForRegistration" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetAgendaItemResponsesForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="UpdateAgendaItemResponsesForRegistration">
+            <soap12:operation soapAction="http://www.regonline.com/api/UpdateAgendaItemResponsesForRegistration" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:UpdateAgendaItemResponsesForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponses">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetCustomFieldResponses" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetCustomFieldResponsesTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponsesForRegistration">
+            <soap12:operation soapAction="http://www.regonline.com/api/GetCustomFieldResponsesForRegistration" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:GetCustomFieldResponsesForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="UpdateCustomFieldResponsesForRegistration">
+            <soap12:operation soapAction="http://www.regonline.com/api/UpdateCustomFieldResponsesForRegistration" style="document" />
+            <wsdl:input>
+                <soap12:body use="literal" />
+                <soap12:header message="tns:UpdateCustomFieldResponsesForRegistrationTokenHeader" part="TokenHeader" use="literal" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap12:body use="literal" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="RegOnline_x0020_APIHttpGet" type="tns:RegOnline_x0020_APIHttpGet">
+        <http:binding verb="GET" />
+        <wsdl:operation name="CheckinRegistrationsForEvent">
+            <http:operation location="/CheckinRegistrationsForEvent" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CheckinRegistrationsForAgendaItem">
+            <http:operation location="/CheckinRegistrationsForAgendaItem" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReportsForEvent">
+            <http:operation location="/GetCustomReportsForEvent" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReports">
+            <http:operation location="/GetCustomReports" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetAttendeeMobileAppSettings">
+            <http:operation location="/_GetAttendeeMobileAppSettings" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetOrganizerMobileAppSettings">
+            <http:operation location="/_GetOrganizerMobileAppSettings" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="ValidateSFUser">
+            <http:operation location="/ValidateSFUser" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsByEventID">
+            <http:operation location="/GetRegistrationsByEventID" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Login">
+            <http:operation location="/Login" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrantForPost">
+            <http:operation location="/LoginRegistrantForPost" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output />
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrant">
+            <http:operation location="/LoginRegistrant" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLogin">
+            <http:operation location="/_GuestLogin" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLoginForPost">
+            <http:operation location="/_GuestLoginForPost" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLogin">
+            <http:operation location="/_VerifyGuestLogin" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLoginForPost">
+            <http:operation location="/_VerifyGuestLoginForPost" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccess">
+            <http:operation location="/_VerifyPasswordRequiredToAccess" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccessForPost">
+            <http:operation location="/_VerifyPasswordRequiredToAccessForPost" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output />
+        </wsdl:operation>
+        <wsdl:operation name="CopyEvent">
+            <http:operation location="/CopyEvent" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEvents">
+            <http:operation location="/GetEvents" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetPublicEvents">
+            <http:operation location="/GetPublicEvents" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEvent">
+            <http:operation location="/GetEvent" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetEventForUser">
+            <http:operation location="/_GetEventForUser" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEventStatistics">
+            <http:operation location="/GetEventStatistics" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEventWebsite">
+            <http:operation location="/GetEventWebsite" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForCustomField">
+            <http:operation location="/GetRegistrationsForCustomField" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForAgenda">
+            <http:operation location="/GetRegistrationsForAgenda" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistration">
+            <http:operation location="/GetRegistration" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForEvent">
+            <http:operation location="/GetRegistrationsForEvent" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsMerchandiseForEvent">
+            <http:operation location="/GetRegistrationsMerchandiseForEvent" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrations">
+            <http:operation location="/GetRegistrations" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrations">
+            <http:operation location="/GetIncompleteRegistrations" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrationsForEvent">
+            <http:operation location="/GetIncompleteRegistrationsForEvent" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactions">
+            <http:operation location="/GetTransactions" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransaction">
+            <http:operation location="/GetTransaction" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactionsForEvent">
+            <http:operation location="/GetTransactionsForEvent" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFields">
+            <http:operation location="/GetCustomFields" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItems">
+            <http:operation location="/GetAgendaItems" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldListItems">
+            <http:operation location="/GetCustomFieldListItems" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponses">
+            <http:operation location="/GetCustomFieldResponses" />
+            <wsdl:input>
+                <http:urlEncoded />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:binding name="RegOnline_x0020_APIHttpPost" type="tns:RegOnline_x0020_APIHttpPost">
+        <http:binding verb="POST" />
+        <wsdl:operation name="CheckinRegistrationsForEvent">
+            <http:operation location="/CheckinRegistrationsForEvent" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CheckinRegistrationsForAgendaItem">
+            <http:operation location="/CheckinRegistrationsForAgendaItem" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReportsForEvent">
+            <http:operation location="/GetCustomReportsForEvent" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomReports">
+            <http:operation location="/GetCustomReports" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetAttendeeMobileAppSettings">
+            <http:operation location="/_GetAttendeeMobileAppSettings" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetOrganizerMobileAppSettings">
+            <http:operation location="/_GetOrganizerMobileAppSettings" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="ValidateSFUser">
+            <http:operation location="/ValidateSFUser" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsByEventID">
+            <http:operation location="/GetRegistrationsByEventID" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="Login">
+            <http:operation location="/Login" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrantForPost">
+            <http:operation location="/LoginRegistrantForPost" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output />
+        </wsdl:operation>
+        <wsdl:operation name="LoginRegistrant">
+            <http:operation location="/LoginRegistrant" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLogin">
+            <http:operation location="/_GuestLogin" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GuestLoginForPost">
+            <http:operation location="/_GuestLoginForPost" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLogin">
+            <http:operation location="/_VerifyGuestLogin" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyGuestLoginForPost">
+            <http:operation location="/_VerifyGuestLoginForPost" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output />
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccess">
+            <http:operation location="/_VerifyPasswordRequiredToAccess" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_VerifyPasswordRequiredToAccessForPost">
+            <http:operation location="/_VerifyPasswordRequiredToAccessForPost" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output />
+        </wsdl:operation>
+        <wsdl:operation name="CopyEvent">
+            <http:operation location="/CopyEvent" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEvents">
+            <http:operation location="/GetEvents" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetPublicEvents">
+            <http:operation location="/GetPublicEvents" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEvent">
+            <http:operation location="/GetEvent" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="_GetEventForUser">
+            <http:operation location="/_GetEventForUser" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEventStatistics">
+            <http:operation location="/GetEventStatistics" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetEventWebsite">
+            <http:operation location="/GetEventWebsite" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForCustomField">
+            <http:operation location="/GetRegistrationsForCustomField" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForAgenda">
+            <http:operation location="/GetRegistrationsForAgenda" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistration">
+            <http:operation location="/GetRegistration" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsForEvent">
+            <http:operation location="/GetRegistrationsForEvent" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrationsMerchandiseForEvent">
+            <http:operation location="/GetRegistrationsMerchandiseForEvent" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetRegistrations">
+            <http:operation location="/GetRegistrations" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrations">
+            <http:operation location="/GetIncompleteRegistrations" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetIncompleteRegistrationsForEvent">
+            <http:operation location="/GetIncompleteRegistrationsForEvent" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactions">
+            <http:operation location="/GetTransactions" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransaction">
+            <http:operation location="/GetTransaction" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetTransactionsForEvent">
+            <http:operation location="/GetTransactionsForEvent" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFields">
+            <http:operation location="/GetCustomFields" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetAgendaItems">
+            <http:operation location="/GetAgendaItems" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldListItems">
+            <http:operation location="/GetCustomFieldListItems" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="GetCustomFieldResponses">
+            <http:operation location="/GetCustomFieldResponses" />
+            <wsdl:input>
+                <mime:content type="application/x-www-form-urlencoded" />
+            </wsdl:input>
+            <wsdl:output>
+                <mime:mimeXml part="Body" />
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="RegOnline_x0020_API">
+        <wsdl:port name="RegOnline_x0020_APISoap" binding="tns:RegOnline_x0020_APISoap">
+            <soap:address location="https://www.regonline.com/api/default.asmx" />
+        </wsdl:port>
+        <wsdl:port name="RegOnline_x0020_APISoap12" binding="tns:RegOnline_x0020_APISoap12">
+            <soap12:address location="https://www.regonline.com/api/default.asmx" />
+        </wsdl:port>
+        <wsdl:port name="RegOnline_x0020_APIHttpGet" binding="tns:RegOnline_x0020_APIHttpGet">
+            <http:address location="http://www.regonline.com/api/default.asmx" />
+        </wsdl:port>
+        <wsdl:port name="RegOnline_x0020_APIHttpPost" binding="tns:RegOnline_x0020_APIHttpPost">
+            <http:address location="http://www.regonline.com/api/default.asmx" />
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/tests/soapServer/regonline.wsdl
+++ b/tests/soapServer/regonline.wsdl
@@ -4735,10 +4735,10 @@
     </wsdl:binding>
     <wsdl:service name="RegOnline_x0020_API">
         <wsdl:port name="RegOnline_x0020_APISoap" binding="tns:RegOnline_x0020_APISoap">
-            <soap:address location="https://www.regonline.com/api/default.asmx" />
+            <soap:address location="http://localhost:8000/default.asmx" />
         </wsdl:port>
         <wsdl:port name="RegOnline_x0020_APISoap12" binding="tns:RegOnline_x0020_APISoap12">
-            <soap12:address location="https://www.regonline.com/api/default.asmx" />
+            <soap12:address location="http://localhost:8000/default.asmx" />
         </wsdl:port>
         <wsdl:port name="RegOnline_x0020_APIHttpGet" binding="tns:RegOnline_x0020_APIHttpGet">
             <http:address location="http://www.regonline.com/api/default.asmx" />

--- a/tests/soapServer/soapService.js
+++ b/tests/soapServer/soapService.js
@@ -1,0 +1,92 @@
+module.exports = {
+	'RegOnline_x0020_API': {
+		'RegOnline_x0020_APISoap': {
+			GetEvents: function (args) {
+				console.log(args);
+				return {
+					GetEventsResult: {
+						Success: true,
+						Data: {
+							APIEvent: [
+								{
+									ID: 1905375,
+									CustomerID: 457098,
+									ParentID: 0,
+									Status: 'Testing',
+									Title: 'test 2',
+									StartDate: '2016 - 11 - 22 T00: 00: 00.000 Z',
+									EndDate: '2016 - 11 - 24 T00: 00: 00.000 Z',
+									ClientEventID: '',
+									TypeID: 1,
+									City: '',
+									State: '',
+									Country: '',
+									CountryCode: '',
+									PostalCode: '',
+									LocationName: '',
+									LocationRoom: '',
+									LocationPhone: '',
+									LocationBuilding: '',
+									LocationAddress1: '',
+									LocationAddress2: '',
+									TimeZone: 'Mountain Time',
+									CurrencyCode: 'USD',
+									Keywords: '',
+									AddDate: '2016 - 11 - 14 T08: 50: 46.283 Z',
+									AddBy: 'traydev',
+									ModDate: '2016 - 11 - 16 T06: 56: 55.960 Z',
+									ModBy: 'traydev',
+									Channel: '',
+									IsWaitlisted: false,
+									Culture: 'English (United States)',
+									MediaType: '',
+									IsActive: false,
+									IsOnSite: false,
+									InternalNotes: ''
+								},
+								{
+									ID: 1904543,
+									CustomerID: 457098,
+									ParentID: 0,
+									Status: 'Testing',
+									Title: 'My test event',
+									StartDate: '2016 - 11 - 24 T08: 00: 00.000 Z',
+									EndDate: '2016 - 11 - 24 T08: 00: 00.000 Z',
+									ClientEventID: '',
+									TypeID: 1,
+									City: '',
+									State: '',
+									Country: '',
+									CountryCode: '',
+									PostalCode: '',
+									LocationName: '',
+									LocationRoom: '',
+									LocationPhone: '',
+									LocationBuilding: '',
+									LocationAddress1: '',
+									LocationAddress2: '',
+									TimeZone: 'Mountain Time',
+									CurrencyCode: 'USD',
+									Keywords: '',
+									AddDate: '2016 - 11 - 09 T19: 35: 18.480 Z',
+									AddBy: 'traydev',
+									ModDate: '2016 - 11 - 15 T12: 27: 20.470 Z',
+									ModBy: 'traydev',
+									Channel: '',
+									IsWaitlisted: false,
+									Culture: 'English (United States)',
+									MediaType: '',
+									IsActive: false,
+									IsOnSite: false,
+									InternalNotes: ''
+								}
+							]
+						},
+						StatusCode: 0,
+						Authority: 0
+					}
+				};
+			}
+		}
+	}
+};

--- a/tests/soapServer/soapService.js
+++ b/tests/soapServer/soapService.js
@@ -1,92 +1,101 @@
+const methodFunctions = {
+	GetEvents: function (...getEventsArgs) {
+		console.log('here = GetEvents');
+		// console.log(getEventsArgs);
+		return {
+			GetEventsResult: {
+				Success: true,
+				Data: {
+					APIEvent: [
+						{
+							ID: 1905375,
+							CustomerID: 457098,
+							ParentID: 0,
+							Status: 'Testing',
+							Title: 'test 2',
+							StartDate: '2016 - 11 - 22 T00: 00: 00.000 Z',
+							EndDate: '2016 - 11 - 24 T00: 00: 00.000 Z',
+							ClientEventID: '',
+							TypeID: 1,
+							City: '',
+							State: '',
+							Country: '',
+							CountryCode: '',
+							PostalCode: '',
+							LocationName: '',
+							LocationRoom: '',
+							LocationPhone: '',
+							LocationBuilding: '',
+							LocationAddress1: '',
+							LocationAddress2: '',
+							TimeZone: 'Mountain Time',
+							CurrencyCode: 'USD',
+							Keywords: '',
+							AddDate: '2016 - 11 - 14 T08: 50: 46.283 Z',
+							AddBy: 'traydev',
+							ModDate: '2016 - 11 - 16 T06: 56: 55.960 Z',
+							ModBy: 'traydev',
+							Channel: '',
+							IsWaitlisted: false,
+							Culture: 'English (United States)',
+							MediaType: '',
+							IsActive: false,
+							IsOnSite: false,
+							InternalNotes: ''
+						},
+						{
+							ID: 1904543,
+							CustomerID: 457098,
+							ParentID: 0,
+							Status: 'Testing',
+							Title: 'My test event',
+							StartDate: '2016 - 11 - 24 T08: 00: 00.000 Z',
+							EndDate: '2016 - 11 - 24 T08: 00: 00.000 Z',
+							ClientEventID: '',
+							TypeID: 1,
+							City: '',
+							State: '',
+							Country: '',
+							CountryCode: '',
+							PostalCode: '',
+							LocationName: '',
+							LocationRoom: '',
+							LocationPhone: '',
+							LocationBuilding: '',
+							LocationAddress1: '',
+							LocationAddress2: '',
+							TimeZone: 'Mountain Time',
+							CurrencyCode: 'USD',
+							Keywords: '',
+							AddDate: '2016 - 11 - 09 T19: 35: 18.480 Z',
+							AddBy: 'traydev',
+							ModDate: '2016 - 11 - 15 T12: 27: 20.470 Z',
+							ModBy: 'traydev',
+							Channel: '',
+							IsWaitlisted: false,
+							Culture: 'English (United States)',
+							MediaType: '',
+							IsActive: false,
+							IsOnSite: false,
+							InternalNotes: ''
+						}
+					]
+				},
+				StatusCode: 0,
+				Authority: 0
+			}
+		};
+	}
+};
+
+// module.exports = {
+// 	'RegOnlineService': {
+// 		'RegOnlinePort': methodFunctions
+// 	}
+// };
 module.exports = {
 	'RegOnline_x0020_API': {
-		'RegOnline_x0020_APISoap': {
-			GetEvents: function (args) {
-				console.log(args);
-				return {
-					GetEventsResult: {
-						Success: true,
-						Data: {
-							APIEvent: [
-								{
-									ID: 1905375,
-									CustomerID: 457098,
-									ParentID: 0,
-									Status: 'Testing',
-									Title: 'test 2',
-									StartDate: '2016 - 11 - 22 T00: 00: 00.000 Z',
-									EndDate: '2016 - 11 - 24 T00: 00: 00.000 Z',
-									ClientEventID: '',
-									TypeID: 1,
-									City: '',
-									State: '',
-									Country: '',
-									CountryCode: '',
-									PostalCode: '',
-									LocationName: '',
-									LocationRoom: '',
-									LocationPhone: '',
-									LocationBuilding: '',
-									LocationAddress1: '',
-									LocationAddress2: '',
-									TimeZone: 'Mountain Time',
-									CurrencyCode: 'USD',
-									Keywords: '',
-									AddDate: '2016 - 11 - 14 T08: 50: 46.283 Z',
-									AddBy: 'traydev',
-									ModDate: '2016 - 11 - 16 T06: 56: 55.960 Z',
-									ModBy: 'traydev',
-									Channel: '',
-									IsWaitlisted: false,
-									Culture: 'English (United States)',
-									MediaType: '',
-									IsActive: false,
-									IsOnSite: false,
-									InternalNotes: ''
-								},
-								{
-									ID: 1904543,
-									CustomerID: 457098,
-									ParentID: 0,
-									Status: 'Testing',
-									Title: 'My test event',
-									StartDate: '2016 - 11 - 24 T08: 00: 00.000 Z',
-									EndDate: '2016 - 11 - 24 T08: 00: 00.000 Z',
-									ClientEventID: '',
-									TypeID: 1,
-									City: '',
-									State: '',
-									Country: '',
-									CountryCode: '',
-									PostalCode: '',
-									LocationName: '',
-									LocationRoom: '',
-									LocationPhone: '',
-									LocationBuilding: '',
-									LocationAddress1: '',
-									LocationAddress2: '',
-									TimeZone: 'Mountain Time',
-									CurrencyCode: 'USD',
-									Keywords: '',
-									AddDate: '2016 - 11 - 09 T19: 35: 18.480 Z',
-									AddBy: 'traydev',
-									ModDate: '2016 - 11 - 15 T12: 27: 20.470 Z',
-									ModBy: 'traydev',
-									Channel: '',
-									IsWaitlisted: false,
-									Culture: 'English (United States)',
-									MediaType: '',
-									IsActive: false,
-									IsOnSite: false,
-									InternalNotes: ''
-								}
-							]
-						},
-						StatusCode: 0,
-						Authority: 0
-					}
-				};
-			}
-		}
+		'RegOnline_x0020_APISoap': methodFunctions,
+		'RegOnline_x0020_APISoap12': methodFunctions
 	}
 };

--- a/tests/soapServer/soapService.js
+++ b/tests/soapServer/soapService.js
@@ -1,7 +1,5 @@
 const methodFunctions = {
 	GetEvents: function (...getEventsArgs) {
-		console.log('here = GetEvents');
-		// console.log(getEventsArgs);
 		return {
 			GetEventsResult: {
 				Success: true,
@@ -88,11 +86,6 @@ const methodFunctions = {
 	}
 };
 
-// module.exports = {
-// 	'RegOnlineService': {
-// 		'RegOnlinePort': methodFunctions
-// 	}
-// };
 module.exports = {
 	'RegOnline_x0020_API': {
 		'RegOnline_x0020_APISoap': methodFunctions,

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,0 +1,26 @@
+const devMode = process.env.NODE_ENV === 'development';
+const handleDevFlagTest = (
+	devMode ?
+	it :
+	(testMessage, testFunction) => {
+		if (testFunction.length) { //Check whether the function expects any args
+			it(testMessage, (done) => {
+				process.env.NODE_ENV = 'development';
+				testFunction((...doneArgs) => {
+					delete process.env.NODE_ENV;
+					done(...doneArgs);
+				});
+			});
+		} else {
+			it(testMessage, () => {
+				process.env.NODE_ENV = 'development';
+				testFunction();
+				delete process.env.NODE_ENV;
+			});
+		}
+	}
+);
+
+module.exports = {
+	handleDevFlagTest
+};


### PR DESCRIPTION
- `type` flag is introduced with values `REST` and `SOAP` (case insensitive)
  - README updated
  - Global tests have been updated
- `soap` flag now has deprecation warning
- linting fixes for some files including test files
- SOAP and REST tests updated, with a test for `type` flag
  - SOAP tests have been further updated to now uses a dummy SOAP server on localhost instead of making calls to RegOnline
    - dummy credentials have been removed from tests

Note: this will be merged into a release branch. This contains the version bump for that release.