### PR TITLE
CPS-178: method function or moustache

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Runs **before** any templating or requests.
 
 ### method (required)
 
-The HTTP method you'd like to use. Valid values are:
+The HTTP verb to use for the request. Valid values are:
 
 * `post`
 * `put`
@@ -111,6 +111,8 @@ The HTTP method you'd like to use. Valid values are:
 * `head`
 
 The values you declare here are **not case sensitive**.
+
+As of v1.11.0, `method` can be a function or mustaching can be used to provide one of the valid values.
 
 ### options
 

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -93,9 +93,6 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 
 			}
 
-			// Method, always lowercased
-			var method = config.method.toLowerCase();
-
 			// Kick off that promise chain
 			when()
 
@@ -110,6 +107,9 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 				params = result;
 
 				logger.info(methodName+': substituting parameters');
+
+				// Method, always lowercased
+				var method = globalize.method.call(threadneedle, config, params);
 
 				// Add a temp file parameter for file handling operations
 				if (config.fileHandler === true) {
@@ -213,6 +213,8 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 
 						}
 					};
+
+					var method = request.method;
 
 					// console.log(options);
 					logger.info(methodName + ': running ' + method + ' request', request);

--- a/lib/addMethod/globalize/baseUrl.js
+++ b/lib/addMethod/globalize/baseUrl.js
@@ -10,7 +10,7 @@ const localOnly = require('./localOnly');
 
 const URL_PROPERTY_ERROR_MESSAGE = '`url` in global configuration is deprecated. Use `baseUrl` instead.';
 
-module.exports = function (config, params) {
+function processUrl (config, params) {
 
 	if (localOnly(config, 'baseUrl')) {
 		return substitute(config.url, params);
@@ -27,16 +27,28 @@ module.exports = function (config, params) {
 
 	//Ordering is significant - if globals true, global should run first
 	const subbedGlobalUrl = substitute(this._globalOptions.baseUrl || this._globalOptions.url, params);
-	const subbedUrl = substitute(config.url, params);
+	const subbedUrl = (
+		config.url === '' ?
+		config.url :
+		substitute(config.url, params)
+	);
 
 	// Add the URL
-	if (_.isString(subbedGlobalUrl) &&
+	return (
+		_.isString(subbedGlobalUrl) &&
 		!startsWith(subbedUrl, 'http://') &&
-		!startsWith(subbedUrl, 'https://')
-	) {
-		return subbedGlobalUrl + subbedUrl;
-	} else {
-		return subbedUrl;
-	}
+		!startsWith(subbedUrl, 'https://') ?
+		subbedGlobalUrl + subbedUrl :
+		subbedUrl
+	);
 
+}
+
+module.exports = function (config, params) {
+	const processedUrl = processUrl.call(this, config, params);
+	if (_.isString(processedUrl) && processedUrl !== '') {
+		return processedUrl;
+	} else {
+		throw new Error('A valid URL has not been supplied.');
+	}
 };

--- a/lib/addMethod/globalize/index.js
+++ b/lib/addMethod/globalize/index.js
@@ -1,12 +1,13 @@
 module.exports = {
-  baseUrl: require('./baseUrl'),
-  string: require('./string'),
-  object: require('./object'),
-  before: require('./before'),
-  beforeRequest: require('./beforeRequest'),
-  expects: require('./expects'),
-  notExpects: require('./notExpects'),
-  afterSuccess: require('./afterSuccess'),
-  afterHeaders: require('./afterHeaders'),
-  afterFailure: require('./afterFailure')
+	method: require('./method'),
+	baseUrl: require('./baseUrl'),
+	string: require('./string'),
+	object: require('./object'),
+	before: require('./before'),
+	beforeRequest: require('./beforeRequest'),
+	expects: require('./expects'),
+	notExpects: require('./notExpects'),
+	afterSuccess: require('./afterSuccess'),
+	afterHeaders: require('./afterHeaders'),
+	afterFailure: require('./afterFailure')
 };

--- a/lib/addMethod/globalize/method.js
+++ b/lib/addMethod/globalize/method.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const substitute = require('../substitute');
 
 module.exports = function (config, params) {

--- a/lib/addMethod/globalize/method.js
+++ b/lib/addMethod/globalize/method.js
@@ -1,0 +1,22 @@
+const _ = require('lodash');
+
+const substitute = require('../substitute');
+
+module.exports = function (config, params) {
+
+	const method = substitute(config.method, params).toLowerCase();
+
+	switch (method) {
+		case 'head':
+		case 'options':
+		case 'get':
+		case 'post':
+		case 'put':
+		case 'patch':
+		case 'delete':
+			return method;
+		default:
+			throw new Error(`Invalid method: ${method}\n'method' must be a valid HTTP verb.`);
+	}
+
+};

--- a/lib/addMethod/globalize/string.js
+++ b/lib/addMethod/globalize/string.js
@@ -2,10 +2,10 @@
     Given the keys for both local and global field, return the substituted
     string with global prepending the local string
 */
-var _          = require('lodash');
+const _ = require('lodash');
 
-var substitute = require('../substitute');
-var localOnly = require('./localOnly');
+const substitute = require('../substitute');
+const localOnly = require('./localOnly');
 
 module.exports = function (config, params, key, globalKey) {
 
@@ -16,7 +16,7 @@ module.exports = function (config, params, key, globalKey) {
 	}
 
 	//Ordering is significant - if globals true, global should run first
-	var subbedGlobalString = substitute(this._globalOptions[globalKey], params) || '',
+	const subbedGlobalString = substitute(this._globalOptions[globalKey], params) || '',
 		subbedMethodString = substitute(config[key], params) || '';
 
 	// Return the full string

--- a/lib/addMethod/globalize/string.js
+++ b/lib/addMethod/globalize/string.js
@@ -9,21 +9,21 @@ var localOnly = require('./localOnly');
 
 module.exports = function (config, params, key, globalKey) {
 
-    globalKey = globalKey || key;
+	globalKey = globalKey || key;
 
-    if (localOnly(config, globalKey)) {
-        return substitute(config[key], params) || '';
-    }
+	if (localOnly(config, globalKey)) {
+		return substitute(config[key], params) || '';
+	}
 
-    //Ordering is significant - if globals true, global should run first
-    var subbedGlobalString = substitute(this._globalOptions[globalKey], params) || '',
-        subbedMethodString = substitute(config[key], params) || '';
+	//Ordering is significant - if globals true, global should run first
+	var subbedGlobalString = substitute(this._globalOptions[globalKey], params) || '',
+		subbedMethodString = substitute(config[key], params) || '';
 
-    // Return the full string
-    return (
+	// Return the full string
+	return (
         _.isString(subbedGlobalString) ?
         subbedGlobalString + subbedMethodString :
         subbedMethodString
-    );
+	);
 
 };

--- a/lib/addMethod/identifySimpleMustache.js
+++ b/lib/addMethod/identifySimpleMustache.js
@@ -1,0 +1,14 @@
+/*
+	Check if the mustaching being used is simple for purposes of smart
+	substitution.
+	Simple mustache is defined by the fact the string only contains a single
+	mustache and is the only thing present in the string.
+	E.g:
+		`url: '{{url}}'` is simple.
+		`url: test.com/{{endpint}}` is not simple, since `{{endpint}}` is not on
+			its own. This also means any extra whitespace prefixing or suffixing
+			the mustache is not simple.
+*/
+module.exports = function (template) {
+	return template.match(/^({{([^{}]+)}}|{{{([^{}]+)}}})$/g);
+};

--- a/lib/addMethod/substitute.js
+++ b/lib/addMethod/substitute.js
@@ -1,5 +1,7 @@
-var Mustache = require('mustache');
 var _        = require('lodash');
+var Mustache = require('mustache');
+
+var identifySimpleMustache = require('./identifySimpleMustache');
 
 module.exports = evaluateAndProcess;
 
@@ -17,12 +19,12 @@ function evaluateAndProcess (template, params) {
 
 }
 
-function substituteString(template, params) {
+function substituteString (template, params) {
 
 	// Smart substitution. If there's a single variable that's been substituted
 	// into a field (which is what happens most of the time), then extract the key
 	// and return the real value.
-	if (template.match(/^({{([^{}]+)}}|{{{([^{}]+)}}})$/g)) {
+	if (identifySimpleMustache(template)) {
 		var key = _.trim(template.match(/(?!{)([^{}]+)(?=})/g)[0]);
 		var value = _.get(params, key, '');
 		if (value !== '') {
@@ -74,13 +76,13 @@ function substituteHashParameters (template, params) {
 
 }
 
-function substituteArray(template, params) {
+function substituteArray (template, params) {
 	return _.map(template, function (value) {
 		return evaluateAndProcess(value, params);
 	});
 }
 
-function substituteObject(template, params) {
+function substituteObject (template, params) {
 	//The `accumulator` variable is the output object being built
 	return _.reduce(template, function (accumulator, value, key) {
 		accumulator[key] = evaluateAndProcess(value, params);

--- a/lib/addMethod/validateRESTInput.js
+++ b/lib/addMethod/validateRESTInput.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 
+const identifySimpleMustache = require('./identifySimpleMustache');
+
 module.exports = function (methodName, config) {
 
 	// Ensure the minimum parameters have been passed
@@ -28,7 +30,7 @@ module.exports = function (methodName, config) {
 	let method = config.method;
 
 	if (_.isString(method)) {
-		if (!method.match(/^({{([^{}]+)}}|{{{([^{}]+)}}})$/g)) {
+		if (!identifySimpleMustache(method)) {
 			method = method.toLowerCase();
 			const allowedMethods = [ 'get', 'put', 'post', 'delete', 'head', 'patch' ];
 			if (allowedMethods.indexOf(method) === -1) {

--- a/lib/addMethod/validateRESTInput.js
+++ b/lib/addMethod/validateRESTInput.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
 module.exports = function (methodName, config) {
 
@@ -27,8 +27,8 @@ module.exports = function (methodName, config) {
 	if (!config.method || !_.isString(config.method)) {
 		throw new Error('The `method` config parameter should be declared as string.');
 	}
-	var method = config.method.toLowerCase();
-	var allowedMethods = [ 'get', 'put', 'post', 'delete', 'head', 'patch' ];
+	const method = config.method.toLowerCase();
+	const allowedMethods = [ 'get', 'put', 'post', 'delete', 'head', 'patch' ];
 	if (allowedMethods.indexOf(method) === -1) {
 		throw new Error('The `method` "'+method+'" is not a valid method. Allowed methods are: '+allowedMethods.join(', '));
 	}

--- a/lib/addMethod/validateRESTInput.js
+++ b/lib/addMethod/validateRESTInput.js
@@ -21,7 +21,7 @@ module.exports = function (methodName, config) {
 	}
 
 	// Ensure the config parameters have been specified correctly
-	if (!config.url) {
+	if (!config.url && config.url !== '') {
 		throw new Error('The `url` config parameter should be declared.');
 	}
 	if (!config.method || !_.isString(config.method)) {

--- a/lib/addMethod/validateRESTInput.js
+++ b/lib/addMethod/validateRESTInput.js
@@ -24,13 +24,19 @@ module.exports = function (methodName, config) {
 	if (!config.url && config.url !== '') {
 		throw new Error('The `url` config parameter should be declared.');
 	}
-	if (!config.method || !_.isString(config.method)) {
-		throw new Error('The `method` config parameter should be declared as string.');
-	}
-	const method = config.method.toLowerCase();
-	const allowedMethods = [ 'get', 'put', 'post', 'delete', 'head', 'patch' ];
-	if (allowedMethods.indexOf(method) === -1) {
-		throw new Error('The `method` "'+method+'" is not a valid method. Allowed methods are: '+allowedMethods.join(', '));
+
+	let method = config.method;
+
+	if (_.isString(method)) {
+		if (!method.match(/^({{([^{}]+)}}|{{{([^{}]+)}}})$/g)) {
+			method = method.toLowerCase();
+			const allowedMethods = [ 'get', 'put', 'post', 'delete', 'head', 'patch' ];
+			if (allowedMethods.indexOf(method) === -1) {
+				throw new Error('The `method` "'+method+'" is not a valid method. Allowed methods are: '+allowedMethods.join(', '));
+			}
+		}
+	} else if (!_.isFunction(method)) {
+		throw new Error('The `method` parameter needs to be provided in the method configuration.');
 	}
 
 };

--- a/lib/addMethod/validateRESTInput.js
+++ b/lib/addMethod/validateRESTInput.js
@@ -2,35 +2,35 @@ var _ = require('lodash');
 
 module.exports = function (methodName, config) {
 
-  // Ensure the minimum parameters have been passed
-  if (!methodName || !_.isString(methodName)) {
-    throw new Error('The first parameter passed to `addMethod` should be a string.');
-  }
-  // If a function is inputted as the `config`, then just return - there's
-  // really not much to validate.
-  if (_.isFunction(config)) {
-    return;
-  }
-  if (!config || !_.isObject(config)) {
-    throw new Error('The `config` object should be an object.');
-  }
+	// Ensure the minimum parameters have been passed
+	if (!methodName || !_.isString(methodName)) {
+		throw new Error('The first parameter passed to `addMethod` should be a string.');
+	}
+	// If a function is inputted as the `config`, then just return - there's
+	// really not much to validate.
+	if (_.isFunction(config)) {
+		return;
+	}
+	if (!config || !_.isObject(config)) {
+		throw new Error('The `config` object should be an object.');
+	}
 
-  // Check to see if the method has already been declared
-  if (!_.isUndefined(this[methodName])) {
-    throw new Error('Method `'+methodName+'` has already been declared.');
-  }
+	// Check to see if the method has already been declared
+	if (!_.isUndefined(this[methodName])) {
+		throw new Error('Method `'+methodName+'` has already been declared.');
+	}
 
-  // Ensure the config parameters have been specified correctly
-  if (!config.url) {
-    throw new Error('The `url` config parameter should be declared.');
-  }
-  if (!config.method || !_.isString(config.method)) {
-    throw new Error('The `method` config parameter should be declared as string.');
-  }
-  var method = config.method.toLowerCase();
-  var allowedMethods = ['get', 'put', 'post', 'delete', 'head', 'patch'];
-  if (allowedMethods.indexOf(method) === -1) {
-    throw new Error('The `method` "'+method+'" is not a valid method. Allowed methods are: '+allowedMethods.join(', '));
-  }
+	// Ensure the config parameters have been specified correctly
+	if (!config.url) {
+		throw new Error('The `url` config parameter should be declared.');
+	}
+	if (!config.method || !_.isString(config.method)) {
+		throw new Error('The `method` config parameter should be declared as string.');
+	}
+	var method = config.method.toLowerCase();
+	var allowedMethods = [ 'get', 'put', 'post', 'delete', 'head', 'patch' ];
+	if (allowedMethods.indexOf(method) === -1) {
+		throw new Error('The `method` "'+method+'" is not a valid method. Allowed methods are: '+allowedMethods.join(', '));
+	}
 
 };

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -156,15 +156,15 @@ describe('#globalize', function () {
 			});
 
 			it('should error for invalid method', () => {
+				let returnedMethod;
 				try {
-					const returnedMethod = globalize.method.call(
+					returnedMethod = globalize.method.call(
 						sample,
 						{
 							method: 'test'
 						},
 						{}
 					);
-					assert.fail(returnedMethod);
 				} catch (methodError) {
 					assert(_.includes(
 						methodError.message,
@@ -174,7 +174,9 @@ describe('#globalize', function () {
 						methodError.message,
 						'\'method\' must be a valid HTTP verb.'
 					));
+					return;
 				}
+				assert.fail(returnedMethod);
 			});
 
 		});

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -185,7 +185,7 @@ describe('#globalize', function () {
 
 	describe('#url', function () {
 
-		it('should add the global baseUrl on the front unless it starts with http(s)://', function () {
+		it('should add the global baseUrl on the front unless method url starts with http(s)://', function () {
 			var sample = {
 				_globalOptions: {
 					baseUrl: 'http://mydomain.com'
@@ -263,6 +263,45 @@ describe('#globalize', function () {
 			);
 		});
 
+		it('should allow method url to be empty string, but baseUrl must be valid', () => {
+			const sample = {
+				_globalOptions: {
+					baseUrl: 'http://mydomain.com'
+				}
+			};
+
+			assert.strictEqual(
+				globalize.baseUrl.call(sample, { url: '' }, {}),
+				'http://mydomain.com'
+			);
+
+			const sample2 = {
+				_globalOptions: {}
+			};
+
+			assert.strictEqual(
+				globalize.baseUrl.call(sample2, { url: 'http://mydomain.com' }, {}),
+				'http://mydomain.com'
+			);
+		});
+
+		it('should throw error for empty string url', () => {
+			const sample = {
+				_globalOptions: {
+					baseUrl: ''
+				}
+			};
+
+			let returnedUrl;
+			try {
+				returnedUrl = globalize.baseUrl.call(sample, { url: '' }, {});
+			} catch (urlError) {
+				assert(_.includes(urlError.message, 'A valid URL has not been supplied.'));
+				return;
+			}
+			assert.fail(returnedUrl);
+		});
+
 		it('should not run the global when globals is false', function () {
 			var sample = {
 				_globalOptions: {
@@ -281,7 +320,7 @@ describe('#globalize', function () {
 			);
 		});
 
-		describe('should use baseUrl in global configuration instead of url; throw error in development mode', function () {
+		describe('should use `baseUrl` in global configuration instead of `url`; throw error in development mode', function () {
 
 			it('uses baseUrl', function () {
 				assert.strictEqual(

--- a/tests/globalize_test.js
+++ b/tests/globalize_test.js
@@ -15,6 +15,172 @@ const { handleDevFlagTest } = require('./testUtils.js');
 
 describe('#globalize', function () {
 
+	describe('#method', function () {
+
+		it('should allow static method to be set', function () {
+			const sample = {
+				_globalOptions: {}
+			};
+
+			assert.strictEqual(
+				globalize.method.call(sample, { method: 'get' }, {}),
+				'get'
+			);
+			assert.strictEqual(
+				globalize.method.call(sample, { method: 'POST' }, {}),
+				'post'
+			);
+		});
+
+		it('should allow moustaching of method', function () {
+			const sample = {
+				_globalOptions: {}
+			};
+
+			assert.strictEqual(
+				globalize.method.call(sample, { method: '{{method}}' }, { method: 'head' }),
+				'head'
+			);
+			assert.strictEqual(
+				globalize.method.call(sample, { method: '{{method}}' }, { method: 'DELETE' }),
+				'delete'
+			);
+		});
+
+		it('should allow function to return method string', function () {
+			const sample = {
+				_globalOptions: {}
+			};
+
+			assert.strictEqual(
+				globalize.method.call(
+					sample,
+					{
+						method: function (params) {
+							return params.method;
+						}
+					},
+					{
+						method: 'PATCH'
+					}
+				),
+				'patch'
+			);
+		});
+
+		describe('should only allow valid HTTP verbs as methods', function () {
+
+			const validMethods = [
+				'head',
+				'options',
+				'get',
+				'post',
+				'put',
+				'patch',
+				'delete',
+			].map((verb) => {
+				return ( _.sample([ true, false ]) ? verb.toUpperCase() : verb );
+			});
+
+			const sample = {
+				_globalOptions: {}
+			};
+
+			describe('valid methods via static', () => {
+
+				validMethods.forEach((method) => {
+
+					it(`${method}`, () => {
+						assert.strictEqual(
+							globalize.method.call(
+								sample,
+								{
+									method: method
+								},
+								{}
+							),
+							method.toLowerCase()
+						);
+					});
+
+				});
+
+			});
+
+			describe('valid methods via moustaching', () => {
+
+				validMethods.forEach((method) => {
+
+					it(`${method}`, () => {
+						assert.strictEqual(
+							globalize.method.call(
+								sample,
+								{
+									method: '{{method}}'
+								},
+								{
+									method: method
+								}
+							),
+							method.toLowerCase()
+						);
+					});
+
+				});
+
+			});
+
+			describe('valid methods via function', () => {
+
+				validMethods.forEach((method) => {
+
+					it(`${method}`, () => {
+						assert.strictEqual(
+							globalize.method.call(
+								sample,
+								{
+									method: function (params) {
+										return params.method;
+									}
+								},
+								{
+									method: method
+								}
+							),
+							method.toLowerCase()
+						);
+					});
+
+				});
+
+			});
+
+			it('should error for invalid method', () => {
+				try {
+					const returnedMethod = globalize.method.call(
+						sample,
+						{
+							method: 'test'
+						},
+						{}
+					);
+					assert.fail(returnedMethod);
+				} catch (methodError) {
+					assert(_.includes(
+						methodError.message,
+						'Invalid method:'
+					));
+					assert(_.includes(
+						methodError.message,
+						'\'method\' must be a valid HTTP verb.'
+					));
+				}
+			});
+
+		});
+
+	});
+
 	describe('#url', function () {
 
 		it('should add the global baseUrl on the front unless it starts with http(s)://', function () {


### PR DESCRIPTION
- the `method` property in REST configuration can now support moustaching or function
- method `url` can now be an empty string (such that baseUrl alone is used as the endpoint)
  - If the complete URL is an empty string, an error will now be thrown