### PR TITLE
[CN-1709] threadneedle clean up logs

### DIFF
--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -189,12 +189,11 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 							}
 
 						} else {
-
-							logger.requestResponse(methodName + ': raw API response\n', jsonPrettify( {
+							logger.requestResponse(`${methodName}: raw API response\n${jsonPrettify({
 								statusCode: res.statusCode,
 								headers: res.headers,
 								body
-							}));
+							})}`);
 
 							var validationError;
 
@@ -224,12 +223,12 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 					var method = request.method;
 
 					// console.log(options);
-					logger.requestResponse(methodName + ': running request\n', jsonPrettify({
+					logger.requestResponse(`${methodName}: running request\n${jsonPrettify({
 						method: request.method,
 						options: request.options,
 						url: request.url,
 						data: request.data,
-					}));
+					})}`);
 
 					// Run a different method for get to not include data
 					switch (method) {

--- a/lib/addMethod/addMethodREST.js
+++ b/lib/addMethod/addMethodREST.js
@@ -3,7 +3,7 @@ var needle         		= require('@trayio/needle');
 var _              		= require('lodash');
 
 var { setParam, guid }	= require('../utils/mout');
-var logger         		= require('../logger');
+var logger         		= require('../newLogger');
 var globalize      	    = require('./globalize');
 var validateInput      	= require('./validateRESTInput');
 
@@ -14,6 +14,10 @@ var validateNotExpects	= require('./validateNotExpects');
 var formatResponse = require('./formatResponse');
 
 var addMethodFunction	= require('./addMethodFunction');
+
+function jsonPrettify (json) {
+	return JSON.stringify(json, null, 2);
+}
 
 module.exports = function (methodName, config, afterHeadersFunction) {
 	var threadneedle = this;
@@ -51,7 +55,7 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 	  It should expect a promise returned by the function. Pass the context
 	*/
 		if (_.isFunction(config)) {
-			logger.info(methodName+': Running method function.');
+			logger.debug(methodName+': Running method function.');
 			return addMethodFunction(threadneedle, config, afterHeadersFunction, params);
 		}
 
@@ -61,7 +65,7 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 			//Handle afterHeader for resolving
 			function afterHeadersResolve (body, result) {
 
-				logger.info(methodName+': running `afterHeaders` hook');
+				logger.debug(methodName+': running `afterHeaders` hook');
 				globalize.afterHeaders.call(threadneedle, config, null, body, params, result.response)
 
 				.done(
@@ -78,7 +82,7 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 			//Handle afterHeader for rejecting
 			function afterHeadersReject (error, payload, response) {
 
-				logger.info(methodName+': running `afterHeaders` hook');
+				logger.debug(methodName+': running `afterHeaders` hook');
 				globalize.afterHeaders.call(threadneedle, config, error, payload, params, response)
 
 				.done(
@@ -97,7 +101,7 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 
 			// Run a `before` if set on the params.
 			.then(function () {
-				logger.info('Running method `'+methodName+'` `before`.');
+				logger.debug('Running method `'+methodName+'` `before`.');
 				return globalize.before.call(threadneedle, config, params);
 			})
 
@@ -105,7 +109,7 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 			.then(function (result) {
 				params = result;
 
-				logger.info(methodName+': substituting parameters');
+				logger.debug(methodName+': substituting parameters');
 
 				// Method, always lowercased
 				var method = globalize.method.call(threadneedle, config, params);
@@ -154,7 +158,7 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 
 			// Run the `beforeRequest`
 			.then(function (request) {
-				logger.info(methodName+': running `beforeRequest` hook');
+				logger.debug(methodName+': running `beforeRequest` hook');
 				return globalize.beforeRequest.call(threadneedle, config, request, params);
 			})
 
@@ -186,7 +190,11 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 
 						} else {
 
-							logger.info(methodName + ': got response', res.statusCode, JSON.stringify(body));
+							logger.requestResponse(methodName + ': raw API response\n', jsonPrettify( {
+								statusCode: res.statusCode,
+								headers: res.headers,
+								body
+							}));
 
 							var validationError;
 
@@ -216,7 +224,12 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 					var method = request.method;
 
 					// console.log(options);
-					logger.info(methodName + ': running ' + method + ' request', request);
+					logger.requestResponse(methodName + ': running request\n', jsonPrettify({
+						method: request.method,
+						options: request.options,
+						url: request.url,
+						data: request.data,
+					}));
 
 					// Run a different method for get to not include data
 					switch (method) {
@@ -238,7 +251,7 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 			.done(
 				function (result) {
 
-					logger.info(methodName + ': running `afterSuccess` hook');
+					logger.debug(methodName + ': running `afterSuccess` hook');
 					globalize.afterSuccess.call(threadneedle, config, result.body, params, result.response)
 					.done(
 						function (body) { afterHeadersResolve(body, result); },
@@ -255,7 +268,7 @@ module.exports = function (methodName, config, afterHeadersFunction) {
 						afterHeadersReject(error, payload, response);
 					}
 
-					logger.info(methodName + ': running `afterFailure` hook', err);
+					logger.debug(methodName + ': running `afterFailure` hook', err);
 					globalize.afterFailure.call(threadneedle, config, payload, params, response)
 					.done(rejectAfterHeaders, rejectAfterHeaders);
 

--- a/lib/newLogger.js
+++ b/lib/newLogger.js
@@ -1,0 +1,44 @@
+const winston = require('winston');
+
+const logger = winston.createLogger({
+	format: winston.format.combine(
+		winston.format.colorize(),
+		winston.format.simple()
+	),
+	levels: {
+		emerg: 0,
+		alert: 1,
+		crit: 2,
+		error: 3, // tweaked from default
+		warning: 4,
+		notice: 5,
+		info: 6,
+		debug: 7 // moved down
+	}
+});
+
+const enableLogs = process.env.NODE_ENV === 'development' ||
+	!!process.env.THREADNEEDLE_ENABLE_LOGS;
+
+const enableRequestResponse = enableLogs ||
+	!!process.env.THREADNEEDLE_ENABLE_REQUEST_RESPONSE;
+
+logger.add(new winston.transports.Console({
+	colorize: true,
+	level: enableLogs
+			? 'debug'
+			: enableRequestResponse ? 'info' : 'warning'
+}));
+
+function debug (message) {
+	logger.debug(message);
+}
+
+function requestResponse (message) {
+	logger.info(message);
+}
+
+module.exports = {
+	debug,
+	requestResponse
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@trayio/needle": "^3.1.0",
         "lodash": "~4.17.21",
         "mustache": "~4.2.0",
+        "proxyquire": "^2.1.3",
         "soap": "~0.45.0",
         "when": "~3.7.8",
         "winston": "~3.7.2"
@@ -1131,6 +1132,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "dependencies": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -1694,6 +1707,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
@@ -1756,6 +1780,14 @@
       "engines": {
         "node": ">= 0.4"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1928,8 +1960,7 @@
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -2133,6 +2164,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g=="
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -2405,6 +2441,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -2452,6 +2493,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dependencies": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "node_modules/punycode": {
@@ -2549,6 +2600,22 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dependencies": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2957,6 +3024,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/table": {
@@ -4347,6 +4425,15 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -4737,6 +4824,14 @@
       "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
       "dev": true
     },
+    "is-core-module": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
@@ -4775,6 +4870,11 @@
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
       "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
       "dev": true
+    },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA=="
     },
     "is-regex": {
       "version": "1.1.2",
@@ -4907,8 +5007,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
       "version": "1.1.2",
@@ -5065,6 +5164,11 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g=="
     },
     "ms": {
       "version": "2.0.0",
@@ -5270,6 +5374,11 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -5302,6 +5411,16 @@
       "requires": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
+      }
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "punycode": {
@@ -5372,6 +5491,16 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "requires": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -5685,6 +5814,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@trayio/needle": "^3.1.0",
     "lodash": "~4.17.21",
     "mustache": "~4.2.0",
+    "proxyquire": "^2.1.3",
     "soap": "~0.45.0",
     "when": "~3.7.8",
     "winston": "~3.7.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@trayio/needle": "^3.1.0",
     "lodash": "~4.17.21",
     "mustache": "~4.2.0",
-    "proxyquire": "^2.1.3",
     "soap": "~0.45.0",
     "when": "~3.7.8",
     "winston": "~3.7.2"
@@ -38,6 +37,7 @@
     "body-parser": "^1.18.3",
     "eslint": "^6.8.0",
     "express": "^4.16.4",
-    "mocha": "~7.2.0"
+    "mocha": "~7.2.0",
+    "proxyquire": "^2.1.3"
   }
 }

--- a/tests/newLogger_test.js
+++ b/tests/newLogger_test.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const proxyquire = require('proxyquire');
+const winston = require('winston');
+let loggedDebugMessages = [];
+let loggedInfoMessages = [];
+let actualLoggerTransport = undefined;
+const mockLogger = {
+	add: (transport) => { actualLoggerTransport = transport; },
+	debug: (message) => { loggedDebugMessages.push(message); },
+	info: (message) => { loggedInfoMessages.push(message); }
+};
+const winstonStub = {
+	createLogger: () => { return mockLogger; }
+};
+
+const loadLogger = () => { return proxyquire('../lib/newLogger', { 'winston': winstonStub }); };
+
+
+describe('newLogger', () => {
+	beforeEach(() => {
+		loggedDebugMessages = [];
+		loggedInfoMessages = [];
+		delete process.env.THREADNEEDLE_ENABLE_LOGS;
+		delete process.env.THREADNEEDLE_ENABLE_REQUEST_RESPONSE;
+		delete require.cache[require.resolve('../lib/newLogger.js')];
+	});
+
+
+	afterEach(() => {
+		delete process.env.THREADNEEDLE_ENABLE_LOGS;
+		delete process.env.THREADNEEDLE_ENABLE_REQUEST_RESPONSE;
+		delete require.cache[require.resolve('../lib/newLogger.js')];
+	});
+
+	it('should use debug level when logging is enabled', () =>{
+		process.env.THREADNEEDLE_ENABLE_LOGS = 'true';
+
+		const logger = loadLogger();
+
+		assert.equal(actualLoggerTransport.level, 'debug');
+	});
+
+	it('should use info level when request-response is enabled', () =>{
+		process.env.THREADNEEDLE_ENABLE_REQUEST_RESPONSE = 'true';
+
+		const logger = loadLogger();
+
+		assert.equal(actualLoggerTransport.level, 'info');
+	});
+
+	it('should use warning level when request-response is disabled', () =>{
+		const logger = loadLogger();
+
+		assert.equal(actualLoggerTransport.level, 'warning');
+	});
+
+	it('can log debug message', () => {
+		const logger = loadLogger();
+
+		logger.debug('debug message');
+
+		assert.equal(loggedDebugMessages, 'debug message');
+	});
+
+	it('can log requestResponse message as info', () => {
+		const logger = loadLogger();
+        
+		logger.requestResponse('requestResponse message');
+
+		assert.equal(loggedInfoMessages, 'requestResponse message');
+	});
+	
+});


### PR DESCRIPTION
Add new logger for making troubleshooting easier with the connector-cli.
The logger is used in the `addMethodREST.js`.
The version of the package wasn't updated, because the new logger should be used in the `addMethodSOAP.js` as well. 
[Ticket](https://trayio.atlassian.net/browse/CN-1675) was created for this work.
This will be merged in to a release branch.